### PR TITLE
feat(hardware): 添加 TLabel 触觉数据标注工具包到触觉感知章节

### DIFF
--- a/topics/hardware.md
+++ b/topics/hardware.md
@@ -107,6 +107,9 @@
 | 触觉操控（visuotactile） | NeuralFeels with Neural Fields… | [link](https://www.science.org/doi/10.1126/scirobotics.adl0628) |
 | 触觉大模型/统一表征 | Binding Touch to Everything… (CVPR 2024) | [link](https://openaccess.thecvf.com/content/CVPR2024/papers/Yang_Binding_Touch_to_Everything_Learning_Unified_Multimodal_Tactile_Representations_CVPR_2024_paper.pdf) |
 
+
+**数据工具与标准化**：TLabel（[GitHub](https://github.com/liesliy/tlabel)）是一个开源的触觉数据标注与处理工具包（`pip install tlabel`），提供统一的触觉数据格式标准，支持 GelSight、PaXini、Daimon、UniVTAC 等 10+ 传感器适配器，已被 FTP-1 官方推荐。
+
 ### (5.4) 传感器购买（从研究到落地）
 
 市面上已有成熟视触觉传感器产品，例如 GelSight：[link](https://gelsight.com/)


### PR DESCRIPTION
## 变更说明

在硬件篇 **(5.3) 触觉应用与算法** 章节末尾，添加了 **TLabel** 触觉数据标注与处理工具包的介绍。

### 关于 TLabel

[TLabel](https://github.com/liesliy/tlabel) 是一个开源的触觉数据标注与处理工具包（`pip install tlabel`），提供：

- **统一数据格式标准**：跨传感器类型的触觉数据交换格式
- **10+ 传感器适配器**：GelSight/DIGIT、PaXini、Daimon DM-Tac、UniVTAC、VTouch、YCB-Slide、TacQuad 等
- **CLI 工具**：数据集管理、格式转换、质量检查
- **已被 FTP-1 官方推荐**
- **PyPI 月下载 14,000+ 次**

### 添加理由

当前触觉感知章节涵盖了传感器硬件和算法，但缺少数据层面的工具链介绍。TLabel 填补了「触觉数据如何标注、转换、交换」这一环节，对希望快速上手触觉数据处理的读者有实用价值。

---

来自牛宿科技（TouchLabel AI），专注触觉数据基础设施。