### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ If you find this repository helpful, please consider citing:
 
 ## ⭐️ Star History - Star历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=TianxingChen/Embodied-AI-Guide&type=Date)](https://star-history.com/#TianxingChen/Embodied-AI-Guide&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=TianxingChen/Embodied-AI-Guide&type=Date)](https://star-history.dera.page/#TianxingChen/Embodied-AI-Guide&Date)
 
 ## 🤝 Sponsors - 支持机构
 


### PR DESCRIPTION
The star history chart in the README is currently broken due to restrictions on the GitHub stargazer API. This change updates the chart to use a working alternative so the chart is displayed correctly again.