### PR TITLE
Refresh content and fix broken links across the guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ WhynotTV、TianxingChen（陈天行）、穆尧_YaoMarkMu、许华哲 Harry、�
 
 ### (3.6) 年度趋势总结
 
+- 1,228 篇 VLA 论文里的数据问题（2026.06，实证分析：VLA 论文量同比增长 5 倍）：[website](https://labelstud.io/blog/vla-robot-data-problem/)
+- VLA 数据集 / 基准 / 数据引擎综述（2026.04）：[arXiv](https://arxiv.org/abs/2604.23001)｜[repo](https://github.com/ziyaow1010/vla-datasets-benchmarks)
 - State of Robot Learning（Dec 2025）：[website](https://vedder.io/misc/state_of_robot_learning_dec_2025.html)
 - 许华哲 - 具身智能：2025 回望：[website](https://zhuanlan.zhihu.com/p/1983661736180589668)
 - 林天威 - 具身 VLA 的 2025：从 Demo 到通用的距离：[website](https://zhuanlan.zhihu.com/p/1989799567177307432)
@@ -297,7 +299,8 @@ WhynotTV、TianxingChen（陈天行）、穆尧_YaoMarkMu、许华哲 Harry、�
   - [(5.0) 参考与综述](./topics/algorithm.md#vla)
   - [(5.1) 经典工作](./topics/algorithm.md#vla)
   - [(5.2) 分层双系统 VLA](./topics/algorithm.md#vla)
-  - [(5.3) 最新 VLA 工作](./topics/algorithm.md#vla)
+  - [(5.3) 2025 年代表工作](./topics/algorithm.md#vla)
+  - [(5.4) 2026 进展](./topics/algorithm.md#vla)
 - [(6) Computer Vision —— 计算机视觉](./topics/algorithm.md#cv)
   - [(6.1) 2D / 3D / 4D Vision](./topics/algorithm.md#cv)
   - [(6.2) Visual Prompting & Affordance](./topics/algorithm.md#cv)

--- a/README.md
+++ b/README.md
@@ -230,7 +230,9 @@ bash scripts/eval_policy.sh multitask \
 石麻日记、Lumina 具身智能、机器之心、新智元、量子位、具身智能研究室、具身纪元、Human Five、Xbot 具身知识库、具身智能之心、自动驾驶之心、3D 视觉工坊、将门创投、RLCN 强化学习研究、CVHub
 
 **中文（小红书博主）**  
-WhynotTV、TianxingChen（陈天行）、穆尧_YaoMarkMu、许华哲 Harry、周博宇、高飞、李弘扬、朱政、丁琰、YY 硕、Mango-Man、RHOSLab #PI-李永露、正合时宜、心言任永亮、York Yang-Dyna Robotics、哲伦班长
+WhynotTV、TianxingChen（陈天行）、穆尧_YaoMarkMu、许华哲 Harry、周博宇、高飞、李弘扬、朱政、丁琰、YY 硕、Mango-Man、RHOSLab #PI-李永露、正合时宜、心言任永亮、York Yang-Dyna Robotics、哲伦班长、吴翼、丁文超、陈思衡、韩晓光、梁俊卫
+
+> 小红书上曾有一场 AI 学者 Ask Me Anything 活动，多位具身与机器人方向的老师在其中答疑，[精华实录](https://www.pingwest.com/a/308126)可作为寻找值得关注账号的线索。
 
 **社区与 wiki**
 

--- a/README.md
+++ b/README.md
@@ -1,194 +1,426 @@
-![](./files/Embodied-AI-Guide-logo.png)
+![Embodied-AI-Guide](./files/Embodied-AI-Guide-logo.png)
 
-<h1 align="center">具身智能技术指南 Embodied-AI-Guide</h1>
+# 具身智能技术指南 Embodied-AI-Guide
 
-> 📚 国内最热门的具身智能技术指南，一个偏「百科全书」定位的具身智能中文知识库与资料索引。欢迎 **Star / 分享 / 提 PR**，欢迎邮件联系 <a href="mailto:lumina.embodiedai@gmail.com">lumina.embodiedai@gmail.com</a> 或 [项目发起人](https://tianxingchen.github.io/) 微信 <code>TianxingChen_2002</code>（请备注机构+姓名与来意）。  
+**国内最热门的具身智能技术指南**  
+一份偏「百科全书」定位的具身智能中文知识库与资料索引
 
-### 📢 News｜项目进展
+[从这里开始](#start) · [动手学习](#robotwin) · [认知资料](#info) · [算法篇](#algorithm) · [基础设施篇](#infrastructure) · [控制篇](#control) · [硬件篇](#hardware)
 
-📷 *2026-01-15: Embodied-AI-Guide重组织完成*<br>
-⭐️ *2025-12-18: GitHub Stars 突破 10,000*<br>
-❤️ *2025-03-15: Embodied-AI-Guide正式开源*
+![GitHub repo stars](https://img.shields.io/github/stars/TianxingChen/Embodied-AI-Guide?style=flat-square)  ![Visitors](https://api.visitorbadge.io/api/visitors?path=https%3A%2F%2Fgithub.com%2FTianxingChen%2FEmbodied-AI-Guide&label=Total%20Visitors&labelColor=%232ccce4&countColor=%23d9e3f0)  ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square)  ![License](https://img.shields.io/badge/License-Non--Commercial-blue?style=flat-square)
 
-<img src="https://img.shields.io/github/stars/TianxingChen/Embodied-AI-Guide?style=flat-square" alt="GitHub repo stars" height="20"/> <img src="https://api.visitorbadge.io/api/visitors?path=https%3A%2F%2Fgithub.com%2FTianxingChen%2FEmbodied-AI-Guide&label=Total%20Visitors&labelColor=%232ccce4&countColor=%23d9e3f0" alt="Visitors" height="20"/>
+> 📚 本项目希望帮助新人**快速建立领域认知**：以一个实践项目带大家动手入门具身智能，同时以百科全书的形式梳理当前具身智能涉及的主要技术，让大家清楚不同技术能解决什么问题，未来想深入时有头绪。
+>
+> 欢迎 **Star / 分享 / 提 PR**。合作与交流可邮件联系 [lumina.embodiedai@gmail.com](mailto:lumina.embodiedai@gmail.com)，或添加[项目发起人](https://tianxingchen.github.io/)微信 `TianxingChen_2002`（请备注：机构 + 姓名 + 来意）。
 
-### 🧑‍💻 Related Open-source Projects｜相关开源项目
 
-⭐️ Lumina Call (具身智能照片): [Website](https://lumina-embodied.ai/lumina-call)<br>
-⭐️ Datawhale Easy-Embodied: [Repo](https://github.com/datawhalechina/every-embodied)
 
-## 🦉 Lumina具身智能社区: [点击访问](https://lumina-embodied.ai)
+## 📢 News｜项目进展
 
-**扫描右下图加入`Lumina具身智能`社区**:
 
-<img src="./files/images/Lumina.png" alt="Task Descriptions">
+| 时间         | 进展                          |
+| ---------- | --------------------------- |
+| 2026-01-15 | 📷 Embodied-AI-Guide 完成内容重组 |
+| 2025-12-18 | ⭐️ GitHub Stars 突破 10,000   |
+| 2025-03-15 | ❤️ Embodied-AI-Guide 正式开源   |
+
+
+
+
+## 🧑‍💻 Related Projects｜相关开源项目
+
+
+| 项目                      | 简介       | 入口                                                       |
+| ----------------------- | -------- | -------------------------------------------------------- |
+| Lumina Call             | 具身智能招聘   | [Website](https://lumina-embodied.ai/lumina-call)        |
+| Datawhale Easy-Embodied | 具身智能入门教程 | [Repo](https://github.com/datawhalechina/every-embodied) |
+
+
+
+
+## 🦉 Lumina 具身智能社区
+
+社区主页：[lumina-embodied.ai](https://lumina-embodied.ai)｜扫描下方二维码即可加入社区交流群：
+
+![Lumina 具身智能社区](./files/images/Lumina.png)
+
+## 📖 目录
+
+
+| 章节                                           | 内容概览                                         |
+| -------------------------------------------- | -------------------------------------------- |
+| [🐣 (1) Start From Here](#start)             | 领域定义、学习路线、术语速查与团队介绍                          |
+| [⚒️ (2) 动手学习具身智能操作](#robotwin)               | 基于 RoboTwin 2.0 走通一次操作策略的完整生命周期 |
+| [📄 (3) Useful Info](#info)                  | 方法论、社区生态、论文列表与年度趋势                           |
+| [🍎 (4) Algorithm](#algorithm)               | 工程工具、视觉表征、机器人学习、VLA、导航与具身 + X                |
+| [🏋️‍♂️ (5) Infrastructure](#infrastructure) | 仿真器、基准集与数据集                                  |
+| [🎮 (6) Control](#control)                   | 控制理论、机器人学、SLAM 与工程生态                         |
+| [🦾 (7) Hardware](#hardware)                 | 嵌入式、机械设计、传感器与数据采集硬件                          |
+
+
+
+
+<a id="start"></a>
 
 ## 🐣 (1) Start From Here - 从这里开始
 
-> 具身智能是指一种基于物理实体进行感知和行动的智能系统, 其通过智能体与环境的交互获取信息、理解问题、做出决策并实现行动, 从而产生智能行为和适应性。
+> 具身智能是指一种基于物理实体进行感知和行动的智能系统，其通过智能体与环境的交互获取信息、理解问题、做出决策并实现行动，从而产生智能行为和适应性。
+
+
 
 ### (1.1) How - 如何使用这份指南
 
-我们希望的是帮助新人快速建立领域认知, 所以设计理念是：**简要**以一个实践项目带大家动手学习具身智能，同时以**百科全书形式**介绍目前具身智能涉及到的主要技术, 让大家知道不同的技术能够解决什么问题, 未来想要深入发展的时候能够有头绪。
+本项目的设计理念是「一条主线 + 一张全景图」：
 
-### (1.2) About us - 关于我们
-我们是一个由具身初学者组成的团队, 希望能够通过我们自己的学习经验, 为后来者提供一些帮助, 加快具身智能的普及。欢迎更多朋友加入我们的项目, 也很欢迎交友、学术合作, 有任何问题, 可以联系邮箱`chentianxing2002@gmail.com`。
+- **一条主线**：用[第 2 章](#robotwin)的实践教程，让你在一周内亲手跑通一个操作策略的完整流程；
+- **一张全景图**：用[第 3 ~ 7 章](#info)以百科全书的形式覆盖算法、基础设施、控制与硬件，帮助你判断每项技术解决什么问题、值不值得深入。
 
-<a href="https://github.com/TianxingChen/Embodied-AI-Guide/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=TianxingChen/Embodied-AI-Guide" />
-</a>
+建议的阅读顺序：**先动手跑通第 2 章，再按兴趣检索后续章节**，不必按顺序通读。
 
-<section id="robotwin"></section>
+### (1.2) 学习路线建议（按背景选择起点）
+
+不同背景的读者不必从同一处入手，可参考下表选择起点：
+
+
+| 你的背景                | 建议起点                    | 推荐路径                                               |
+| ------------------- | ----------------------- | -------------------------------------------------- |
+| 完全新手 / 在校本科生        | [第 2 章](#robotwin) 动手教程 | (2) 跑通流程 → (3) 建立认知 → (4) 算法篇 → 按兴趣深入              |
+| 有 CV / NLP / 深度学习基础 | [第 4 章](#algorithm) 算法篇 | (4) 重点看 Robot Learning 与 VLA → (5) 基础设施 → (2) 动手验证 |
+| 有自动化 / 机器人学背景       | [第 4 章](#algorithm) 算法篇 | (3) 了解版图 → (4) 补齐学习与决策 → (5) 熟悉仿真与数据生态             |
+| 偏硬件 / 嵌入式           | [第 7 章](#hardware) 硬件篇  | (7) 硬件篇 → (6) 控制篇 → (2) 动手教程                       |
+| 想快速了解行业与选题          | [第 3 章](#info) 认知资料     | (3.1) 方法论 → (3.5) 论文列表 → (3.6) 年度趋势                |
+
+
+
+
+### (1.3) 术语速查表
+
+阅读论文与本指南时高频出现的概念，先建立字面认知即可，细节留给对应章节：
+
+
+| 术语                              | 一句话解释                               |
+| ------------------------------- | ----------------------------------- |
+| **Manipulation / Locomotion**   | 操作（用手臂改变环境）与移动（用腿或轮子移动本体），具身智能的两条主线 |
+| **Policy（策略）**                  | 从观测到动作的映射，也就是日常所说的「模型」              |
+| **IL / BC（模仿学习 / 行为克隆）**        | 从人类演示数据中以监督方式学习动作                   |
+| **RL（强化学习）**                    | 通过与环境交互并依据奖励信号来优化策略                 |
+| **VLA（Vision-Language-Action）** | 直接把图像与语言指令映射为机器人动作的端到端模型            |
+| **VA（Vision-Action）**           | 只用视觉、不接受语言指令的策略；任务固定时比 VLA 更轻更快      |
+| **World Model（世界模型）**          | 学习「当前状态 + 动作 → 下一步观测」的模型，可用来在脑内推演      |
+| **WAM（World-Action Model）**     | 先用世界模型预测接下来会看到什么，再从预测中解出动作的一类策略       |
+| **Teleoperation（遥操作）**          | 人通过手柄、动捕或主从设备操控机器人，是真机数据采集的主要手段     |
+| **Demonstration（演示 / 轨迹）**      | 一次完整的任务执行记录，通常包含观测、动作与时间戳           |
+| **Sim2Real Gap**                | 仿真与真实世界在物理、渲染、噪声上的差异，会导致策略迁移掉点      |
+| **Real2Sim**                    | 把真实场景与物体重建进仿真，用于缩小 Sim2Real Gap     |
+| **Affordance（可操作性）**            | 物体上「可以被怎样操作」的区域或方式，如把手可抓、按钮可按       |
+| **DoF（自由度）**                    | 机器人可独立运动的关节数量                       |
+| **End-effector（末端执行器）**         | 机械臂末端的执行部件，如夹爪、吸盘、灵巧手               |
+| **FK / IK（正 / 逆运动学）**           | 由关节角求末端位姿 / 由末端位姿反解关节角              |
+| **URDF**                        | 描述机器人连杆、关节与惯量的 XML 格式，是仿真与控制的通用输入   |
+| **MPC（模型预测控制）**                 | 在滚动时域内反复求解优化问题来生成控制量                |
+| **WBC（全身控制）**                   | 把控制目标从机械臂末端扩展到躯干、腿、头等整个身体，人形机器人方向常用  |
+| **SLAM**                        | 同时定位与建图，让机器人知道「自己在哪、周围长什么样」         |
+
+
+
+
+### (1.4) About Us - 关于我们
+
+我们是一个由具身智能初学者组成的团队，希望以自己的学习经验为后来者提供帮助，加快具身智能的普及。欢迎更多朋友加入项目，也欢迎交友与学术合作。有任何问题可联系邮箱 [chentianxing2002@gmail.com](mailto:chentianxing2002@gmail.com)。
+
+![Contributors](https://contrib.rocks/image?repo=TianxingChen/Embodied-AI-Guide)
+
+<a id="robotwin"></a>
 
 ## ⚒️ (2) 动手学习具身智能操作
 
-> **建议一周内完成学习**，使用**RoboTwin 2.0**平台走通一个操作策略“生命周期”的全流程<br>
-> **完成此教程需要至少16GB显存的显卡**
+> **目标**：以 **RoboTwin 2.0** 为例，完整走通一次操作策略的「生命周期」——读论文建立认知、装环境、拿数据、训练 ACT、跑评测。这条链路本身是通用的，换成别的平台也是同样几步。
+>
+> **前置条件**：一块显存不低于 16GB 的显卡（ACT 训练约需 12GB）。官方建议数据采集与策略评测**避开 A / H / V 系列显卡**，详见 [Common Issue](https://robotwin-platform.github.io/doc/common-issue/)。
 
-### (2.1) 为什么这样选择这个教程
 
-具身智能操作是一个很复杂的问题：**数据从哪来**、**策略怎么设计（架构与训练细节）**、**怎么评测模型性能（平台与任务设计）**。
 
-**数据从哪来**：具身智能的数据有很多种源头，比如真机数据采集、人类视频数据、仿真合成数据、世界模型合成数据等等，其中各有各的问题，比如真机数据采集成本高、人类视频数据信息含量低、仿真合成数据Sim2Real Gap与Scaleup难题、世界模型合成数据存在幻觉等。
+### (2.1) 为什么选择这个教程
 
-**策略怎么设计**：不同的网络架构选择影响模型的表现、收敛效果、推理速度等。
+具身智能操作是一个复杂的系统问题，可以拆成三个核心环节：
 
-**怎么评测模型性能**：评测是非常重要的，否则我们不知道科学评价模型效果如何，也没办法推动技术发展。
+- **数据从哪来**：常见来源包括真机采集、人类视频、仿真合成与世界模型合成，各有短板——真机采集成本高、人类视频信息含量低、仿真合成面临 Sim2Real Gap 与 Scale-up 难题、世界模型合成存在幻觉；
+- **策略怎么设计**：网络架构的选择直接影响模型表现、收敛效果与推理速度；
+- **怎么评测性能**：没有科学的评测，就无法判断模型好坏，也难以推动技术进步。
 
-面对以上问题，<a href="https://robotwin-platform.github.io/">RoboTwin 2.0平台</a>为广大科研学者提供了非常好的学习平台，RoboTwin 2.0基于易配置的<a href="https://sapien.ucsd.edu/">SAPIEN</a>仿真平台开发，提供了50个双臂自动化数据合成、主流操作策略训测集成、评测系统，能够辅助大家快速走起来具身智能操作策略的生命周期。过程中也可以多看看数据与评测视频，了解数据分布与策略表现。
+面对以上问题，[RoboTwin 2.0](https://robotwin-platform.github.io/)（ICML 2026）提供了一个很好的学习平台。它基于易配置的 [SAPIEN](https://sapien.ucsd.edu/) 仿真平台开发，提供 50 个双臂任务的自动化数据合成与统一评测系统，并已开源 **10 万条以上预采集轨迹**——这意味着新手可以跳过最耗时的数据采集环节，直接从训练开始。
+
+需要注意的是，策略侧的代码现在放在 [XPolicyLab](https://github.com/XPolicyLab/XPolicyLab) 这个子模块里，训练和评测脚本都从那里调用，所以下面的步骤会用到它。它把不同策略的训练与评测收敛到了同一套接口，对学习者的实际好处是：走完一遍 ACT 之后，想换成 π0、RDT-1B 这类 VLA 试试，主要改的是策略名和配置文件，不用从头再理解一套工程。
+
+过程中建议多看合成数据与评测回放视频，以建立对数据分布和策略失败模式的直觉。
 
 ### (2.2) 学习流程
 
-RoboTwin 2.0：[代码](https://github.com/robotwin-Platform/robotwin) ｜ [主页](https://robotwin-platform.github.io/) ｜ [文档](https://robotwin-platform.github.io/doc/) ｜ [论文](https://arxiv.org/abs/2506.18088)
 
-<details>
-<summary><b>展开学习流程</b></summary>
+| 资源                   | 链接                                                                                                                                                                                   |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| RoboTwin 2.0         | [代码](https://github.com/RoboTwin-Platform/RoboTwin)｜[主页](https://robotwin-platform.github.io/)｜[文档](https://robotwin-platform.github.io/doc/)｜[论文](https://arxiv.org/abs/2506.18088) |
+| XPolicyLab（策略侧代码）    | [代码](https://github.com/XPolicyLab/XPolicyLab)｜[文档](https://robotwin-platform.github.io/doc/usage/xpolicylab.html)                                                                   |
+| 50 个双臂任务说明           | [Tasks Doc](https://robotwin-platform.github.io/doc/tasks/)                                                                                                                          |
+| 官方榜单                 | [Leaderboard](https://robotwin-platform.github.io/leaderboard)                                                                                                                       |
+| 跑完之后可以看看             | [RoboDojo](https://robodojo-benchmark.com/)（仿真 + 真机统一评测）｜[RMBench](https://rmbench.github.io/)（记忆依赖操作）                                                                               |
 
-#### (2.2.1) 了解RoboTwin 2.0做了什么 (～1天)
 
-阅读RoboTwin 2.0论文[paper](https://arxiv.org/pdf/2506.18088)，了解仿真数据合成的方案，深入理解对于合成一条机器人数据需要什么信息，机器人有什么可以做的任务，了解[Aloha](https://www.bilibili.com/video/BV1vU421d7BJ/?spm_id_from=333.337.search-card.all.click&vd_source=ab9cf5374617c2867aaea34af29b53c9)硬件。
 
-#### (2.2.2) 配置RoboTwin 2.0平台，数据采集 (~0.5天)
+| 阶段      | 内容                     | 预计耗时    |
+| ------- | ---------------------- | ------- |
+| (2.2.1) | 了解 RoboTwin 2.0 做了什么   | 约 1 天   |
+| (2.2.2) | 安装平台（含 XPolicyLab 子模块） | 约 0.5 天 |
+| (2.2.3) | 准备数据（下载预采集 / 自行采集）     | 约 0.5 天 |
+| (2.2.4) | 训练 ACT 策略              | 约 1 天   |
+| (2.2.5) | 评测策略并对照榜单              | 约 1 天   |
 
-环境安装教学: [Tutorial](https://robotwin-platform.github.io/doc/usage/robotwin-install.html)，根据以下数据采集脚本采集`beat_block_hammer`任务50条:
 
+
+
+#### (2.2.1) 了解 RoboTwin 2.0 做了什么（约 1 天）
+
+阅读 [RoboTwin 2.0 论文](https://arxiv.org/pdf/2506.18088)，了解仿真数据合成的方案，深入理解合成一条机器人数据需要哪些信息、机器人可以完成什么任务，并了解 [Aloha](https://www.bilibili.com/video/BV1vU421d7BJ/) 硬件。
+
+#### (2.2.2) 安装平台（约 0.5 天）
+
+按[安装文档](https://robotwin-platform.github.io/doc/usage/robotwin-install.html)配置环境，整个过程约 20 分钟。**注意 XPolicyLab 现在是 RoboTwin 的 Git 子模块**，克隆时必须递归拉取，否则后续训练与评测会缺文件：
+
+```bash
+# 全新克隆
+git clone --recurse-submodules https://github.com/RoboTwin-Platform/RoboTwin.git
+cd RoboTwin
+
+# 若此前已克隆过，补拉子模块即可
+git submodule update --init --recursive XPolicyLab
 ```
+
+
+
+#### (2.2.3) 准备数据（约 0.5 天）
+
+官方已开源 10 万条以上轨迹，**推荐直接下载**，可以省掉数小时的采集时间。下面只取本教程用到的 `beat_block_hammer` 任务：
+
+```bash
+# 只下载指定任务；不传参数则下载全部任务
+bash scripts/download_xpolicylab_data.sh beat_block_hammer
+```
+
+数据会落在 `data/demo_clean/<task_name>/aloha_agilex/data/`。
+
+只有当你需要自定义任务配置、域随机化或更换机器人本体时，才需要自己采集。采集脚本会先搜索能成功完成任务的随机种子，再回放种子录制轨迹：
+
+```bash
 bash collect_data.sh ${task_name} ${task_config} ${gpu_id}
-## Clean Data Example: bash collect_data.sh beat_block_hammer demo_clean 0
-## Radomized Data Example: bash collect_data.sh beat_block_hammer demo_randomized 0
+
+# Clean Data Example
+bash collect_data.sh beat_block_hammer demo_clean 0
+
+# Randomized Data Example
+bash collect_data.sh beat_block_hammer demo_randomized 0
 ```
 
-#### (2.2.4) 策略训练（～1天）
+自采数据落在 `data/<task_config>/<task_name>/<embodiment>/data/`，已经是 XPolicyLab 轨迹格式，不需要额外转换。想理解 `demo_clean` 与 `demo_randomized` 的差别，可读[域随机化文档](https://robotwin-platform.github.io/doc/usage/domain-randomization.html)。
 
-选择ACT策略进行复现 [Tutorial](https://robotwin-platform.github.io/doc/usage/ACT.html)，ACT是非常经典的操作策略算法，训练此策略大约需要12GB显存，
+> ⚠️ 读取 HDF5 里的图像时**只能**用 `XPolicyLab.utils.process_data.decode_image_bit`。自己写 `cv2.imdecode` 或 PIL 解码会因为历史数据版本的布局差异而静默颠倒 RGB 通道，这是最容易踩、也最难排查的坑。
 
-#### (2.2.5) 测试策略（～1天）
 
-在`demo_clean`下评测ACT成功率大约是56%（详见[Leaderboard](https://robotwin-platform.github.io/leaderboard)）。
 
-</details>
+#### (2.2.4) 训练 ACT 策略（约 1 天）
 
-<section id="info"></section>
+ACT 是非常经典的操作策略算法，适合作为第一个复现对象，训练大约需要 12GB 显存。策略适配器位于 `XPolicyLab/policy/ACT/`，XPolicyLab 里所有策略都遵循同一套生命周期脚本：
+
+```bash
+cd XPolicyLab/policy/ACT
+bash install.sh                                  # 安装策略侧运行环境
+bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type>
+bash train.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type> <seed> <gpu_id>
+```
+
+同一套参数命名会贯穿数据处理、训练与评测，中途不需要改名：`bench_name` 取 `RoboTwin`；`ckpt_name` 是本次训练的简称，例如 `act_demo`；`env_cfg_type` 用 `arx_x5`（对应 RoboTwin 默认的 aloha-agilex 布局）；`action_type` 一般取 `joint` 或 `ee`。权重会落在 `checkpoints/<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>-<seed>/`。具体参数与显存要求以 [ACT 适配器 README](https://github.com/XPolicyLab/XPolicyLab/blob/main/policy/ACT/README.md) 为准。
+
+#### (2.2.5) 评测策略并对照榜单（约 1 天）
+
+RoboTwin 的所有评测都统一走 `scripts/eval_policy.sh`。调度器会为每个任务各起一个策略服务端和一个仿真器，任务列表与 GPU 配置写在 `env_cfg/eval/all_tasks.yml`——只想评单个任务的话，把 `tasks` 裁成一条即可：
+
+```bash
+bash scripts/eval_policy.sh multitask \
+  --config env_cfg/eval/all_tasks.yml \
+  --policy-name ACT \
+  --ckpt-name <checkpoint> \
+  --env-cfg-type arx_x5 \
+  --policy-conda-env <policy_env> \
+  --eval-env-conda-env <robotwin_env> \
+  --action-type joint
+```
+
+加 `--dry-run` 可以只校验调度计划而不真正启动，结果默认写到 `eval_result/multitask/`。如果本机显卡不够，还可以把策略服务端放在远程机器、仿真器留在本地，用 `--enable-remote` 搭配 `--policy-server-ip / --policy-server-port` 连接，详见 [XPolicyLab 文档](https://robotwin-platform.github.io/doc/usage/xpolicylab.html)。
+
+跑完后把自己的成功率与 [Leaderboard](https://robotwin-platform.github.io/leaderboard) 上 ACT 的官方成绩对照（`demo_clean` 下约 56%）。差距过大通常说明数据量、训练轮数或 `action_type` 没对齐。
+
+至此你已经完整走过一遍操作策略的生命周期。**下一步最划算的动作是换个策略再跑一遍**：把 `--policy-name` 换成 `Pi_0`、`RDT_1B`、`GR00T_N17`、`X_VLA` 中的任意一个，其余流程完全一致，这样能直观感受不同架构在同一任务上的差异。完整策略清单见 [XPolicyLab 文档](https://robotwin-platform.github.io/doc/usage/xpolicylab.html)。
+
+<a id="info"></a>
 
 ## 📄 (3) Useful Info - 有利于搭建认知的资料
 
-这一章主要用于**快速建立对具身智能领域的整体认知**，适合在系统学习算法、工程或硬件之前，用来了解技术版图、社区生态与研究脉络。
+这一章用于**快速建立对具身智能领域的整体认知**，适合在系统学习算法、工程或硬件之前，用来了解技术版图、社区生态与研究脉络。
 
----
+### (3.1) 方向性与方法论资料
 
-**方向性与方法论资料**  
-- 具身智能基础技术路线（Yunlong Dong）：[PDF](./files/具身智能基础技术路线-YunlongDong.pdf) ｜ [bilibili](https://www.bilibili.com/video/BV1d5ukedEsi)  
-- 斯坦福机器人学导论：[website](https://www.bilibili.com/video/BV17T421k78T)  
-- Cyber Nachos（偏系统与工程思维）：[website](https://cybernachos.github.io/)  
+- 具身智能基础技术路线（Yunlong Dong）：[PDF](./files/具身智能基础技术路线-YunlongDong.pdf)｜[bilibili](https://www.bilibili.com/video/BV1d5ukedEsi)
+- 斯坦福机器人学导论：[website](https://www.bilibili.com/video/BV17T421k78T)
+- Cyber Nachos（偏系统与工程思维）：[website](https://cybernachos.github.io/)
 
-**社区 / 社交媒体（长期跟进价值高）**  
-- 公众号：**石麻日记（强烈推荐）**、Lumina具身智能、机器之心、新智元、量子位、具身智能研究室、具身纪元、Human Five、Xbot具身知识库、具身智能之心、自动驾驶之心、3D视觉工坊、将门创投、RLCN强化学习研究、CVHub  
-- 博主（小红书）：WhynotTV、穆尧_YaoMarkMu、许华哲Harry、周博宇、高飞、李弘扬、朱政、丁琰、YY硕、Mango-Man、RHOSLab #PI-李永露、正合时宜、心言任永亮、York Yang-Dyna Robotics、哲伦班长
 
-**实验室与学术生态参考**  
-- Robotics 实验室总结：[zhihu link1](https://zhuanlan.zhihu.com/p/682671294?utm_psn=1782122763157188608) ｜ [zhihu link2](https://zhuanlan.zhihu.com/p/682692024?utm_psn=1782122945184796672)  
-- 具身智能华人高引榜：[repo](https://github.com/Will-Gao/Embodied_Intelligence)  
-- Lumina 具身智能社区：[website](https://lumina-embodied.ai)  
 
-**高质量会议与期刊（论文检索时重点关注）**  
-Science Robotics, TRO, IJRR, JFR, RSS, RAL, IROS, ICRA, ICCV, ECCV, ICML, CVPR, NeurIPS, CoRL, ICLR, AAAI, ACL
+### (3.2) 社区与自媒体（长期跟进价值高）
 
-**长期跟进研究进展与选题调研**
- 
-- Awesome Humanoid Robot Learning（Yanjie Ze）：[repo](https://github.com/YanjieZe/awesome-humanoid-robot-learning)  
-- Paper Reading List（DeepTimber Community）：[repo](https://github.com/DeepTimber-Robot-Lab/Paper-Reading-List)  
-- Paper List（Yanjie Ze）：[repo](https://github.com/YanjieZe/Paper-List)  
-- RoboScholar / Embodied AI Paper List（Tianxing Chen）：[repo](https://github.com/TianxingChen/Paper-List-For-EmbodiedAI)  
-- SOTA Paper Rating（Weiyang Jin）：[website](https://waynejin0918.github.io/SOTA-paper-rating.io/)  
-- Awesome LLM Robotics：[repo](https://github.com/GT-RIPL/Awesome-LLM-Robotics)  
-- Awesome Video Robotic Papers：[repo](https://github.com/H-Freax/Awesome-Video-Robotic-Papers)  
-- Awesome Embodied Robotics and Agent：[repo](https://github.com/zchoi/Awesome-Embodied-Robotics-and-Agent)  
-- awesome-embodied-vla / va / vln：[repo](https://github.com/jonyzhang2023/awesome-embodied-vla-va-vln)  
-- Awesome Affordance Learning：[repo](https://github.com/hq-King/Awesome-Affordance-Learning)  
-- Embodied AI Paper TopConf：[repo](https://github.com/Songwxuan/Embodied-AI-Paper-TopConf)  
-- Awesome **RL-VLA** for Robotic Manipulation (Haoyuan Deng)：[repo](https://github.com/Denghaoyuan123/Awesome-RL-VLA) 
-- Awesome **Efficient-VLA** for Robotic Manipulation (Weifan Guan)：[repo](https://github.com/guanweifan/awesome-efficient-vla) 
-- Awesome Embodied Data：[project](https://jasper-aaa.github.io/embodied-data-pyramid/) ｜ [repo](https://github.com/worldbench/awesome-embodied-data-pyramid) ｜ [arXiv](https://arxiv.org/abs/2607.24744v1)
+**中文（微信公众号）**  
+石麻日记、Lumina 具身智能、机器之心、新智元、量子位、具身智能研究室、具身纪元、Human Five、Xbot 具身知识库、具身智能之心、自动驾驶之心、3D 视觉工坊、将门创投、RLCN 强化学习研究、CVHub
 
-**年度趋势总结**  
-- State of Robot Learning (Dec 2025)：[website](https://vedder.io/misc/state_of_robot_learning_dec_2025.html)
+**中文（小红书博主）**  
+WhynotTV、TianxingChen（陈天行）、穆尧_YaoMarkMu、许华哲 Harry、周博宇、高飞、李弘扬、朱政、丁琰、YY 硕、Mango-Man、RHOSLab #PI-李永露、正合时宜、心言任永亮、York Yang-Dyna Robotics、哲伦班长
 
-- 许华哲 - 具身智能：2025回望，[website](https://zhuanlan.zhihu.com/p/1983661736180589668)
+**中英文站点与社区**（这部分有公开链接，适合直接订阅）
 
-- 林天威 - 具身VLA的2025：从 Demo 到通用的距离，[website](https://zhuanlan.zhihu.com/p/1989799567177307432)
+| 名称 | 链接 | 类型与看点 |
+|---|---|---|
+| Simulately | [website](https://simulately.wiki/) | 社区维护的仿真器 wiki，选仿真器时的第一站 |
+| 巨神研习社 | [website](http://www.jushenyanxishe.com/) | 中文具身智能技术社区 |
+| Import AI（Jack Clark） | [newsletter](https://jack-clark.net/) | 每周一封，偏政策与产业视角，判断力强 |
+| The Batch（DeepLearning.AI） | [newsletter](https://www.deeplearning.ai/the-batch/) | 吴恩达团队的周报，综述性强、门槛低 |
+| Ahead of AI（Sebastian Raschka） | [newsletter](https://magazine.sebastianraschka.com/) | 模型训练与实现细节讲得最清楚的一档 |
+| Humanoid Daily | [website](https://johnkoetsier.com/humanoid-daily/) | 人形机器人行业日更，追产业动态用 |
+| Machine Dawn | [website](https://machinedawn.ai/) | 具身智能与机器人产业观察 |
+| IEEE Spectrum Robotics | [website](https://spectrum.ieee.org/topic/robotics/) | IEEE 官方，硬件与工程报道质量高 |
+| The Robot Report | [website](https://www.therobotreport.com/) | 偏商业化与供应链，了解落地情况 |
+| TWIML AI Podcast | [podcast](https://twimlai.com/podcast/twimlai/) | 长访谈，常有具身方向的一线研究者 |
+| The Robot Brains Podcast | [podcast](https://www.therobotbrains.ai/) | Pieter Abbeel 主持，访谈机器人学习领域研究者 |
+
+
+
+### (3.3) 实验室与学术生态
+
+- Robotics 实验室总结：[zhihu link1](https://zhuanlan.zhihu.com/p/682671294?utm_psn=1782122763157188608)｜[zhihu link2](https://zhuanlan.zhihu.com/p/682692024?utm_psn=1782122945184796672)
+- 具身智能华人高引榜：[repo](https://github.com/Will-Gao/Embodied_Intelligence)
+- Lumina 具身智能社区：[website](https://lumina-embodied.ai)
+
+
+
+### (3.4) 高质量会议与期刊（论文检索时重点关注）
+
+
+| 领域        | 会议 / 期刊                                                      |
+| --------- | ------------------------------------------------------------ |
+| 机器人       | Science Robotics, TRO, IJRR, JFR, RSS, RAL, IROS, ICRA, CoRL |
+| 计算机视觉     | CVPR, ICCV, ECCV                                             |
+| 机器学习      | NeurIPS, ICML, ICLR                                          |
+| 人工智能与自然语言 | AAAI, ACL                                                    |
+
+
+
+
+### (3.5) 论文列表（长期跟进研究进展与选题调研）
+
+- Awesome Humanoid Robot Learning（Yanjie Ze）：[repo](https://github.com/YanjieZe/awesome-humanoid-robot-learning)
+- Paper Reading List（DeepTimber Community）：[repo](https://github.com/DeepTimber-Robot-Lab/Paper-Reading-List)
+- Paper List（Yanjie Ze）：[repo](https://github.com/YanjieZe/Paper-List)
+- RoboScholar / Embodied AI Paper List（Tianxing Chen）：[repo](https://github.com/TianxingChen/Paper-List-For-EmbodiedAI)
+- Awesome LLM Robotics：[repo](https://github.com/GT-RIPL/Awesome-LLM-Robotics)
+- Awesome Video Robotic Papers：[repo](https://github.com/H-Freax/Awesome-Video-Robotic-Papers)
+- Awesome Embodied Robotics and Agent：[repo](https://github.com/zchoi/Awesome-Embodied-Robotics-and-Agent)
+- awesome-embodied-vla / va / vln：[repo](https://github.com/jonyzhang2023/awesome-embodied-vla-va-vln)
+- Awesome Affordance Learning：[repo](https://github.com/hq-King/Awesome-Affordance-Learning)
+- Embodied AI Paper TopConf：[repo](https://github.com/Songwxuan/Embodied-AI-Paper-TopConf)
+- Awesome **RL-VLA** for Robotic Manipulation（Haoyuan Deng）：[repo](https://github.com/Denghaoyuan123/Awesome-RL-VLA)
+- Awesome **Efficient-VLA** for Robotic Manipulation（Weifan Guan）：[repo](https://github.com/guanweifan/awesome-efficient-vla)
+- Awesome Embodied Data：[project](https://jasper-aaa.github.io/embodied-data-pyramid/)｜[repo](https://github.com/worldbench/awesome-embodied-data-pyramid)｜[arXiv](https://arxiv.org/abs/2607.24744v1)
+
+
+
+### (3.6) 年度趋势总结
+
+- State of Robot Learning（Dec 2025）：[website](https://vedder.io/misc/state_of_robot_learning_dec_2025.html)
+- 许华哲 - 具身智能：2025 回望：[website](https://zhuanlan.zhihu.com/p/1983661736180589668)
+- 林天威 - 具身 VLA 的 2025：从 Demo 到通用的距离：[website](https://zhuanlan.zhihu.com/p/1989799567177307432)
+
+
+
+<a id="algorithm"></a>
 
 ## 🍎 (4) Algorithm - 算法篇
 
-这一篇把具身智能中最常用的“算法能力栈”从下往上串了起来：底层是工程工具与几何/标定/控制这类决定系统能否稳定运行的基础；中层是视觉与多模态表征（2D/3D/4D、prompting、affordance），它们把复杂世界压缩成可泛化、可对齐、可被策略利用的中间表示；上层则是学习与决策（RL/IL、VLA、LLM+Planner、快慢系统），把感知与任务目标转成可执行动作，并逐步走向更长程、更通用、更可部署的系统形态。
+> 完整内容：[topics/algorithm.md](./topics/algorithm.md)
 
-- [Common Tools —— 常用工程工具](./topics/algorithm.md#common-tools)
-- [Vision Foundation Models —— 视觉基础模型](./topics/algorithm.md#foundation-models)
-- [Robot Learning —— 机器人学习](./topics/algorithm.md#robot-learning)
-- [LLM for Robotics —— LLM+机器人](./topics/algorithm.md#llm_robot)
-- [VLA —— Vision-Language-Action Models](./topics/algorithm.md#vla)
-  - [5.0 参考与综述](./topics/algorithm.md#vla) 
-  - [5.1 经典工作](./topics/algorithm.md#vla)
-  - [5.2 分层双系统 VLA](./topics/algorithm.md#vla)
-  - [5.3 最新 VLA 工作](./topics/algorithm.md#vla)
-- [Computer Vision —— 计算机视觉](./topics/algorithm.md#cv)
-  - [6.1 2D/3D/4D Vision](./topics/algorithm.md#cv)
-  - [6.2 Visual Prompting & Affordance](./topics/algorithm.md#cv)
-- [Computer Graphics —— 计算机图形学](./topics/algorithm.md#cg)
-- [Multimodal Models —— 多模态模型](./topics/algorithm.md#mm)
-- [Robot Navigation —— 机器人导航](./topics/algorithm.md#navigation)
-- [Embodied AI for X —— 具身智能+X](./topics/algorithm.md#embodied-ai-4-x)
-  - [10.1 Healthcare](./topics/algorithm.md#medical)
-  - [10.2 UAV](./topics/algorithm.md#uav)
-  - [10.3 Autonomous Driving](./topics/algorithm.md#ad)
+这一篇把具身智能中最常用的「算法能力栈」从下往上串了起来：**底层**是工程工具与几何、标定、控制这类决定系统能否稳定运行的基础；**中层**是视觉与多模态表征（2D/3D/4D、prompting、affordance），负责把复杂世界压缩成可泛化、可对齐、可被策略利用的中间表示；**上层**则是学习与决策（RL/IL、VLA、LLM + Planner、快慢系统），把感知与任务目标转成可执行动作，并逐步走向更长程、更通用、更可部署的系统形态。
+
+- [(1) Common Tools —— 常用工程工具](./topics/algorithm.md#common-tools)
+- [(2) Vision Foundation Models —— 视觉基础模型](./topics/algorithm.md#foundation-models)
+- [(3) Robot Learning —— 机器人学习](./topics/algorithm.md#robot-learning)
+- [(4) LLM for Robotics —— LLM + 机器人](./topics/algorithm.md#llm_robot)
+- [(5) VLA —— Vision-Language-Action Models](./topics/algorithm.md#vla)
+  - [(5.0) 参考与综述](./topics/algorithm.md#vla)
+  - [(5.1) 经典工作](./topics/algorithm.md#vla)
+  - [(5.2) 分层双系统 VLA](./topics/algorithm.md#vla)
+  - [(5.3) 最新 VLA 工作](./topics/algorithm.md#vla)
+- [(6) Computer Vision —— 计算机视觉](./topics/algorithm.md#cv)
+  - [(6.1) 2D / 3D / 4D Vision](./topics/algorithm.md#cv)
+  - [(6.2) Visual Prompting & Affordance](./topics/algorithm.md#cv)
+- [(7) Computer Graphics —— 计算机图形学](./topics/algorithm.md#cg)
+- [(8) Multimodal Models —— 多模态模型](./topics/algorithm.md#mm)
+- [(9) Robot Navigation —— 机器人导航](./topics/algorithm.md#navigation)
+- [(10) Embodied AI for X —— 具身智能 + X](./topics/algorithm.md#embodied-ai-4-x)
+  - [(10.1) Healthcare —— 具身医疗](./topics/algorithm.md#medical)
+  - [(10.2) UAV —— 无人机](./topics/algorithm.md#uav)
+  - [(10.3) Autonomous Driving —— 自动驾驶](./topics/algorithm.md#ad)
 
 
-## 🏋️‍♂️ (5) Infrastruture - 软件基础设施篇
 
-这一章关注的不是“具体某个模型”，而是**支撑具身智能研究与系统落地的软件基础设施（Infrastructure）**。仿真器决定你能构建怎样的世界，基准集决定你如何比较方法优劣，数据集决定模型最终学到什么样的行为分布。它们共同构成了具身智能中**最容易被忽视、但最影响上限与复现性的部分**。
+<a id="infrastructure"></a>
 
-- [(1) Simulators - 仿真器](./topics/infrastructure.md#simulators)
-- [(2) Benchmarks - 基准集](./topics/infrastructure.md#benchmarks)
-- [(3) Datasets - 数据集](./topics/infrastructure.md#datasets)
+## 🏋️‍♂️ (5) Infrastructure - 软件基础设施篇
+
+> 完整内容：[topics/infrastructure.md](./topics/infrastructure.md)
+
+这一章关注的不是「具体某个模型」，而是**支撑具身智能研究与系统落地的软件基础设施（Infrastructure）**。仿真器决定你能构建怎样的世界，基准集决定你如何比较方法优劣，数据集决定模型最终学到什么样的行为分布。它们共同构成了具身智能中**最容易被忽视、但最影响上限与复现性的部分**。
+
+- [(1) Simulators —— 仿真器](./topics/infrastructure.md#simulators)
+- [(2) Benchmarks —— 基准集](./topics/infrastructure.md#benchmarks)
+- [(3) Datasets —— 数据集](./topics/infrastructure.md#datasets)
+- [(4) 工具链 —— 数据格式与策略部署](./topics/infrastructure.md#policy-serving)
+
+
+
+<a id="control"></a>
 
 ## 🎮 (6) Control - 控制篇
 
-这一章并不是为了让你“立刻跑一个模型”，而是为具身智能系统提供**稳定性、可解释性与工程底座**。控制论保证系统在高频下不崩溃，机器人学提供几何与动力学约束，SLAM 与状态估计让机器人“知道自己在哪里”，ROS 与工程库则把理论变成可复现的系统。
+> 完整内容：[topics/control.md](./topics/control.md)
+
+这一章并不是为了让你「立刻跑一个模型」，而是为具身智能系统提供**稳定性、可解释性与工程底座**。控制论保证系统在高频下不崩溃，机器人学提供几何与动力学约束，SLAM 与状态估计让机器人「知道自己在哪里」，ROS 与工程库则把理论变成可复现的系统。
 
 - [(1) Control and Robotics —— 控制论与机器人学基础](./topics/control.md#control-robotics)
   - [(1.1) 经典课程](./topics/control.md#control-courses)
-- [(2) 控制理论基础（Control Foundations）](./topics/control.md#control-foundations)
+- [(2) Control Foundations —— 控制理论基础](./topics/control.md#control-foundations)
   - [(2.1) 经典控制（Classical Control）](./topics/control.md#classical-control)
   - [(2.2) 现代控制（最优控制）](./topics/control.md#modern-control)
   - [(2.3) 先进控制（Advanced Control）](./topics/control.md#advanced-control)
-- [(3) 机器人学导论（Robotics Foundations）](./topics/control.md#robotics-foundations)
+- [(3) Robotics Foundations —— 机器人学导论](./topics/control.md#robotics-foundations)
   - [(3.1) 推荐教材与材料](./topics/control.md#robotics-books)
   - [(3.2) 运动学与动力学](./topics/control.md#kinematics-dynamics)
   - [(3.3) 里程计与 SLAM](./topics/control.md#slam)
   - [(3.4) 工程生态与工具](./topics/control.md#engineering-stack)
 
+
+
+<a id="hardware"></a>
+
 ## 🦾 (7) Hardware - 硬件篇
 
-具身智能硬件涵盖多个技术栈：嵌入式软硬件、机械设计、机器人系统集成与传感器等。它们知识面很杂，但共同目标只有一个：把“算法”变成真实世界里稳定可复现的系统。关于硬件学习，最有效的方式几乎永远是 **从实践出发**：先做出一个能跑起来的最小系统，再逐步扩展复杂度与可靠性。
+> 完整内容：[topics/hardware.md](./topics/hardware.md)
+
+具身智能硬件涵盖多个技术栈：嵌入式软硬件、机械设计、机器人系统集成与传感器等。它们知识面很杂，但共同目标只有一个：把「算法」变成真实世界里稳定可复现的系统。关于硬件学习，最有效的方式几乎永远是 **从实践出发**——先做出一个能跑起来的最小系统，再逐步扩展复杂度与可靠性。
 
 - [(1) Embedded —— 嵌入式](./topics/hardware.md#embedded)
 - [(2) Mechanical Design —— 机械设计](./topics/hardware.md#mechanical)
@@ -204,12 +436,22 @@ Science Robotics, TRO, IJRR, JFR, RSS, RAL, IROS, ICRA, ICCV, ECCV, ICML, CVPR, 
 - [(7) Companies —— 公司与硬件生态](./topics/hardware.md#companies)
 
 
-<section id="acknowledgement"></section>
+
+## 🤝 Contributing - 参与贡献
+
+本项目由社区共同维护，欢迎任何形式的参与：
+
+- **补充资料**：在对应篇章的 `topics/*.md` 中按现有条目格式追加，并尽量补上一句话说明这份资料解决什么问题；
+- **修正内容**：发现失效链接、过时结论或表述错误，欢迎直接提 PR 或开 Issue；
+- **改进结构**：对章节组织与学习路线有想法，欢迎在 Issue 中讨论。
+
+提交 PR 前请确认：条目放在了语义最贴近的章节、链接可正常访问、格式与相邻条目保持一致。
 
 ## 👍 Citation - 引用
-If you find this repository helpful, please consider citing:
 
-```
+如果这个仓库对你有帮助，欢迎引用：
+
+```bibtex
 @misc{embodiedaiguide2025,
   title = {Embodied-AI-Guide},
   author = {Embodied-AI-Guide-Contributors, Lumina-Embodied-AI-Community, Tianxing Chen},
@@ -219,28 +461,23 @@ If you find this repository helpful, please consider citing:
 }
 ```
 
-<section id="license"></section>
+
 
 ## 🏷️ License - 许可协议
 
-本项目为 **非商业使用（Non-Commercial Use）** 协议：
+本项目采用 **非商业使用（Non-Commercial Use）** 协议：
 
-- 允许：个人学习、学术研究、非盈利使用；
-- 禁止：任何形式的商业使用，包括但不限于公司/企业内部使用、
-  集成到收费产品或服务中、或用于任何营利目的。
+- **允许**：个人学习、学术研究与其他非盈利用途；
+- **禁止**：任何形式的商业使用，包括但不限于公司/企业内部使用、集成到收费产品或服务中，或用于任何营利目的。
 
-详情请查看仓库中的 [LICENSE](./LICENSE) 文件。
+详情请查看仓库中的 [LICENSE](./LICENSE) 文件。如需商业授权（例如在公司产品或商业项目中使用），请联系项目负责人：[chentianxing2002@gmail.com](mailto:chentianxing2002@gmail.com)。
 
-如需商业授权（例如在公司产品或商业项目中使用），请联系项目负责人：<a href="mailto:chentianxing2002@gmail.com">chentianxing2002@gmail.com</a>。
+## ⭐️ Star History - Star 历史
 
-<section id="star-history"></section>
-
-## ⭐️ Star History - Star历史
-
-[![Star History Chart](https://star-history.dera.page/svg?repos=TianxingChen/Embodied-AI-Guide&type=Date)](https://star-history.dera.page/#TianxingChen/Embodied-AI-Guide&Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=TianxingChen/Embodied-AI-Guide&type=Date)
 
 ## 🤝 Sponsors - 支持机构
 
-感谢 **无界智航、超维动力、香港大学MMLab、地瓜机器人、松灵机器人** 对本项目的支持
+感谢 **无界智航**、**超维动力**、**香港大学 MMLab**、**地瓜机器人**、**松灵机器人** 对本项目的支持。
 
-![](./files/images/sponsor.png)
+![Sponsors](./files/images/sponsor.png)

--- a/README.md
+++ b/README.md
@@ -1,42 +1,38 @@
-![Embodied-AI-Guide](./files/Embodied-AI-Guide-logo.png)
+![](./files/Embodied-AI-Guide-logo.png)
 
-# 具身智能技术指南 Embodied-AI-Guide
+<h1 align="center">具身智能技术指南 Embodied-AI-Guide</h1>
 
-**国内最热门的具身智能技术指南**  
-一份偏「百科全书」定位的具身智能中文知识库与资料索引
+<p align="center">
+  <b>国内最热门的具身智能技术指南</b><br>
+  一份偏「百科全书」定位的具身智能中文知识库与资料索引
+</p>
 
-[从这里开始](#start) · [动手学习](#robotwin) · [认知资料](#info) · [算法篇](#algorithm) · [基础设施篇](#infrastructure) · [控制篇](#control) · [硬件篇](#hardware)
+<p align="center">
+  <a href="#start">从这里开始</a> ·
+  <a href="#robotwin">动手学习</a> ·
+  <a href="#info">认知资料</a> ·
+  <a href="#algorithm">算法篇</a> ·
+  <a href="#infrastructure">基础设施篇</a> ·
+  <a href="#control">控制篇</a> ·
+  <a href="#hardware">硬件篇</a>
+</p>
 
-![GitHub repo stars](https://img.shields.io/github/stars/TianxingChen/Embodied-AI-Guide?style=flat-square)  ![Visitors](https://api.visitorbadge.io/api/visitors?path=https%3A%2F%2Fgithub.com%2FTianxingChen%2FEmbodied-AI-Guide&label=Total%20Visitors&labelColor=%232ccce4&countColor=%23d9e3f0)  ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square)  ![License](https://img.shields.io/badge/License-Non--Commercial-blue?style=flat-square)
+<p align="center"><img src="https://img.shields.io/github/stars/TianxingChen/Embodied-AI-Guide?style=flat-square" alt="GitHub repo stars" height="20"/>  <img src="https://api.visitorbadge.io/api/visitors?path=https%3A%2F%2Fgithub.com%2FTianxingChen%2FEmbodied-AI-Guide&label=Total%20Visitors&labelColor=%232ccce4&countColor=%23d9e3f0" alt="Visitors" height="20"/>  <img src="https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square" alt="PRs Welcome" height="20"/>  <img src="https://img.shields.io/badge/License-Non--Commercial-blue?style=flat-square" alt="License" height="20"/></p>
 
 > 📚 本项目希望帮助新人**快速建立领域认知**：以一个实践项目带大家动手入门具身智能，同时以百科全书的形式梳理当前具身智能涉及的主要技术，让大家清楚不同技术能解决什么问题，未来想深入时有头绪。
 >
 > 欢迎 **Star / 分享 / 提 PR**。合作与交流可邮件联系 [lumina.embodiedai@gmail.com](mailto:lumina.embodiedai@gmail.com)，或添加[项目发起人](https://tianxingchen.github.io/)微信 `TianxingChen_2002`（请备注：机构 + 姓名 + 来意）。
 
+### 📢 News｜项目进展
 
+📷 *2026-01-15: Embodied-AI-Guide 完成内容重组*<br>
+⭐️ *2025-12-18: GitHub Stars 突破 10,000*<br>
+❤️ *2025-03-15: Embodied-AI-Guide 正式开源*
 
-## 📢 News｜项目进展
+### 🧑‍💻 Related Projects｜相关开源项目
 
-
-| 时间         | 进展                          |
-| ---------- | --------------------------- |
-| 2026-01-15 | 📷 Embodied-AI-Guide 完成内容重组 |
-| 2025-12-18 | ⭐️ GitHub Stars 突破 10,000   |
-| 2025-03-15 | ❤️ Embodied-AI-Guide 正式开源   |
-
-
-
-
-## 🧑‍💻 Related Projects｜相关开源项目
-
-
-| 项目                      | 简介       | 入口                                                       |
-| ----------------------- | -------- | -------------------------------------------------------- |
-| Lumina Call             | 具身智能招聘   | [Website](https://lumina-embodied.ai/lumina-call)        |
-| Datawhale Easy-Embodied | 具身智能入门教程 | [Repo](https://github.com/datawhalechina/every-embodied) |
-
-
-
+⭐️ Lumina Call（具身智能招聘）：[Website](https://lumina-embodied.ai/lumina-call)<br>
+⭐️ Datawhale Easy-Embodied（具身智能入门教程）：[Repo](https://github.com/datawhalechina/every-embodied)
 
 ## 🦉 Lumina 具身智能社区
 
@@ -44,29 +40,11 @@
 
 ![Lumina 具身智能社区](./files/images/Lumina.png)
 
-## 📖 目录
-
-
-| 章节                                           | 内容概览                                         |
-| -------------------------------------------- | -------------------------------------------- |
-| [🐣 (1) Start From Here](#start)             | 领域定义、学习路线、术语速查与团队介绍                          |
-| [⚒️ (2) 动手学习具身智能操作](#robotwin)               | 基于 RoboTwin 2.0 走通一次操作策略的完整生命周期 |
-| [📄 (3) Useful Info](#info)                  | 方法论、社区生态、论文列表与年度趋势                           |
-| [🍎 (4) Algorithm](#algorithm)               | 工程工具、视觉表征、机器人学习、VLA、导航与具身 + X                |
-| [🏋️‍♂️ (5) Infrastructure](#infrastructure) | 仿真器、基准集与数据集                                  |
-| [🎮 (6) Control](#control)                   | 控制理论、机器人学、SLAM 与工程生态                         |
-| [🦾 (7) Hardware](#hardware)                 | 嵌入式、机械设计、传感器与数据采集硬件                          |
-
-
-
-
 <a id="start"></a>
 
 ## 🐣 (1) Start From Here - 从这里开始
 
 > 具身智能是指一种基于物理实体进行感知和行动的智能系统，其通过智能体与环境的交互获取信息、理解问题、做出决策并实现行动，从而产生智能行为和适应性。
-
-
 
 ### (1.1) How - 如何使用这份指南
 
@@ -81,7 +59,6 @@
 
 不同背景的读者不必从同一处入手，可参考下表选择起点：
 
-
 | 你的背景                | 建议起点                    | 推荐路径                                               |
 | ------------------- | ----------------------- | -------------------------------------------------- |
 | 完全新手 / 在校本科生        | [第 2 章](#robotwin) 动手教程 | (2) 跑通流程 → (3) 建立认知 → (4) 算法篇 → 按兴趣深入              |
@@ -90,13 +67,12 @@
 | 偏硬件 / 嵌入式           | [第 7 章](#hardware) 硬件篇  | (7) 硬件篇 → (6) 控制篇 → (2) 动手教程                       |
 | 想快速了解行业与选题          | [第 3 章](#info) 认知资料     | (3.1) 方法论 → (3.5) 论文列表 → (3.6) 年度趋势                |
 
-
-
-
 ### (1.3) 术语速查表
 
-阅读论文与本指南时高频出现的概念，先建立字面认知即可，细节留给对应章节：
+阅读论文与本指南时高频出现的概念，先建立字面认知即可，细节留给对应章节。
 
+<details>
+<summary><b>展开术语速查表（20 条）</b></summary>
 
 | 术语                              | 一句话解释                               |
 | ------------------------------- | ----------------------------------- |
@@ -121,8 +97,7 @@
 | **WBC（全身控制）**                   | 把控制目标从机械臂末端扩展到躯干、腿、头等整个身体，人形机器人方向常用  |
 | **SLAM**                        | 同时定位与建图，让机器人知道「自己在哪、周围长什么样」         |
 
-
-
+</details>
 
 ### (1.4) About Us - 关于我们
 
@@ -137,8 +112,6 @@
 > **目标**：以 **RoboTwin 2.0** 为例，完整走通一次操作策略的「生命周期」——读论文建立认知、装环境、拿数据、训练 ACT、跑评测。这条链路本身是通用的，换成别的平台也是同样几步。
 >
 > **前置条件**：一块显存不低于 16GB 的显卡（ACT 训练约需 12GB）。官方建议数据采集与策略评测**避开 A / H / V 系列显卡**，详见 [Common Issue](https://robotwin-platform.github.io/doc/common-issue/)。
-
-
 
 ### (2.1) 为什么选择这个教程
 
@@ -156,27 +129,10 @@
 
 ### (2.2) 学习流程
 
-
-| 资源                   | 链接                                                                                                                                                                                   |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| RoboTwin 2.0         | [代码](https://github.com/RoboTwin-Platform/RoboTwin)｜[主页](https://robotwin-platform.github.io/)｜[文档](https://robotwin-platform.github.io/doc/)｜[论文](https://arxiv.org/abs/2506.18088) |
-| XPolicyLab（策略侧代码）    | [代码](https://github.com/XPolicyLab/XPolicyLab)｜[文档](https://robotwin-platform.github.io/doc/usage/xpolicylab.html)                                                                   |
-| 50 个双臂任务说明           | [Tasks Doc](https://robotwin-platform.github.io/doc/tasks/)                                                                                                                          |
-| 官方榜单                 | [Leaderboard](https://robotwin-platform.github.io/leaderboard)                                                                                                                       |
-| 跑完之后可以看看             | [RoboDojo](https://robodojo-benchmark.com/)（仿真 + 真机统一评测）｜[RMBench](https://rmbench.github.io/)（记忆依赖操作）                                                                               |
-
-
-
-| 阶段      | 内容                     | 预计耗时    |
-| ------- | ---------------------- | ------- |
-| (2.2.1) | 了解 RoboTwin 2.0 做了什么   | 约 1 天   |
-| (2.2.2) | 安装平台（含 XPolicyLab 子模块） | 约 0.5 天 |
-| (2.2.3) | 准备数据（下载预采集 / 自行采集）     | 约 0.5 天 |
-| (2.2.4) | 训练 ACT 策略              | 约 1 天   |
-| (2.2.5) | 评测策略并对照榜单              | 约 1 天   |
-
-
-
+**RoboTwin 2.0**：[代码](https://github.com/RoboTwin-Platform/RoboTwin)｜[主页](https://robotwin-platform.github.io/)｜[文档](https://robotwin-platform.github.io/doc/)｜[论文](https://arxiv.org/abs/2506.18088)<br>
+**XPolicyLab（策略侧代码）**：[代码](https://github.com/XPolicyLab/XPolicyLab)｜[文档](https://robotwin-platform.github.io/doc/usage/xpolicylab.html)<br>
+**任务与榜单**：[50 个双臂任务说明](https://robotwin-platform.github.io/doc/tasks/)｜[Leaderboard](https://robotwin-platform.github.io/leaderboard)<br>
+**跑完之后可以看看**：[RoboDojo](https://robodojo-benchmark.com/)（仿真 + 真机统一评测）｜[RMBench](https://rmbench.github.io/)（记忆依赖操作）
 
 #### (2.2.1) 了解 RoboTwin 2.0 做了什么（约 1 天）
 
@@ -194,8 +150,6 @@ cd RoboTwin
 # 若此前已克隆过，补拉子模块即可
 git submodule update --init --recursive XPolicyLab
 ```
-
-
 
 #### (2.2.3) 准备数据（约 0.5 天）
 
@@ -223,8 +177,6 @@ bash collect_data.sh beat_block_hammer demo_randomized 0
 自采数据落在 `data/<task_config>/<task_name>/<embodiment>/data/`，已经是 XPolicyLab 轨迹格式，不需要额外转换。想理解 `demo_clean` 与 `demo_randomized` 的差别，可读[域随机化文档](https://robotwin-platform.github.io/doc/usage/domain-randomization.html)。
 
 > ⚠️ 读取 HDF5 里的图像时**只能**用 `XPolicyLab.utils.process_data.decode_image_bit`。自己写 `cv2.imdecode` 或 PIL 解码会因为历史数据版本的布局差异而静默颠倒 RGB 通道，这是最容易踩、也最难排查的坑。
-
-
 
 #### (2.2.4) 训练 ACT 策略（约 1 天）
 
@@ -272,8 +224,6 @@ bash scripts/eval_policy.sh multitask \
 - 斯坦福机器人学导论：[website](https://www.bilibili.com/video/BV17T421k78T)
 - Cyber Nachos（偏系统与工程思维）：[website](https://cybernachos.github.io/)
 
-
-
 ### (3.2) 社区与自媒体（长期跟进价值高）
 
 **中文（微信公众号）**  
@@ -282,23 +232,19 @@ bash scripts/eval_policy.sh multitask \
 **中文（小红书博主）**  
 WhynotTV、TianxingChen（陈天行）、穆尧_YaoMarkMu、许华哲 Harry、周博宇、高飞、李弘扬、朱政、丁琰、YY 硕、Mango-Man、RHOSLab #PI-李永露、正合时宜、心言任永亮、York Yang-Dyna Robotics、哲伦班长
 
-**中英文站点与社区**（这部分有公开链接，适合直接订阅）
+**社区与 wiki**
 
-| 名称 | 链接 | 类型与看点 |
-|---|---|---|
-| Simulately | [website](https://simulately.wiki/) | 社区维护的仿真器 wiki，选仿真器时的第一站 |
-| 巨神研习社 | [website](http://www.jushenyanxishe.com/) | 中文具身智能技术社区 |
-| Import AI（Jack Clark） | [newsletter](https://jack-clark.net/) | 每周一封，偏政策与产业视角，判断力强 |
-| The Batch（DeepLearning.AI） | [newsletter](https://www.deeplearning.ai/the-batch/) | 吴恩达团队的周报，综述性强、门槛低 |
-| Ahead of AI（Sebastian Raschka） | [newsletter](https://magazine.sebastianraschka.com/) | 模型训练与实现细节讲得最清楚的一档 |
-| Humanoid Daily | [website](https://johnkoetsier.com/humanoid-daily/) | 人形机器人行业日更，追产业动态用 |
-| Machine Dawn | [website](https://machinedawn.ai/) | 具身智能与机器人产业观察 |
-| IEEE Spectrum Robotics | [website](https://spectrum.ieee.org/topic/robotics/) | IEEE 官方，硬件与工程报道质量高 |
-| The Robot Report | [website](https://www.therobotreport.com/) | 偏商业化与供应链，了解落地情况 |
-| TWIML AI Podcast | [podcast](https://twimlai.com/podcast/twimlai/) | 长访谈，常有具身方向的一线研究者 |
-| The Robot Brains Podcast | [podcast](https://www.therobotbrains.ai/) | Pieter Abbeel 主持，访谈机器人学习领域研究者 |
+- Simulately（社区维护的仿真器 wiki，选仿真器时的第一站）：[website](https://simulately.wiki/)
+- 巨神研习社：[website](http://www.jushenyanxishe.com/)
 
+**英文 newsletter / 媒体 / 播客**
 
+- Import AI（Jack Clark，偏政策与产业视角）：[newsletter](https://jack-clark.net/)
+- The Batch（DeepLearning.AI，综述性强、门槛低）：[newsletter](https://www.deeplearning.ai/the-batch/)
+- Ahead of AI（Sebastian Raschka，训练与实现细节）：[newsletter](https://magazine.sebastianraschka.com/)
+- Humanoid Daily（人形机器人行业日更）：[website](https://johnkoetsier.com/humanoid-daily/)｜Machine Dawn：[website](https://machinedawn.ai/)
+- IEEE Spectrum Robotics：[website](https://spectrum.ieee.org/topic/robotics/)｜The Robot Report（偏商业化与供应链）：[website](https://www.therobotreport.com/)
+- TWIML AI Podcast：[podcast](https://twimlai.com/podcast/twimlai/)｜The Robot Brains（Pieter Abbeel 主持）：[podcast](https://www.therobotbrains.ai/)
 
 ### (3.3) 实验室与学术生态
 
@@ -306,20 +252,10 @@ WhynotTV、TianxingChen（陈天行）、穆尧_YaoMarkMu、许华哲 Harry、�
 - 具身智能华人高引榜：[repo](https://github.com/Will-Gao/Embodied_Intelligence)
 - Lumina 具身智能社区：[website](https://lumina-embodied.ai)
 
-
-
 ### (3.4) 高质量会议与期刊（论文检索时重点关注）
 
-
-| 领域        | 会议 / 期刊                                                      |
-| --------- | ------------------------------------------------------------ |
-| 机器人       | Science Robotics, TRO, IJRR, JFR, RSS, RAL, IROS, ICRA, CoRL |
-| 计算机视觉     | CVPR, ICCV, ECCV                                             |
-| 机器学习      | NeurIPS, ICML, ICLR                                          |
-| 人工智能与自然语言 | AAAI, ACL                                                    |
-
-
-
+**机器人**：Science Robotics, TRO, IJRR, JFR, RSS, RAL, IROS, ICRA, CoRL<br>
+**计算机视觉**：CVPR, ICCV, ECCV｜**机器学习**：NeurIPS, ICML, ICLR｜**AI 与 NLP**：AAAI, ACL
 
 ### (3.5) 论文列表（长期跟进研究进展与选题调研）
 
@@ -337,15 +273,11 @@ WhynotTV、TianxingChen（陈天行）、穆尧_YaoMarkMu、许华哲 Harry、�
 - Awesome **Efficient-VLA** for Robotic Manipulation（Weifan Guan）：[repo](https://github.com/guanweifan/awesome-efficient-vla)
 - Awesome Embodied Data：[project](https://jasper-aaa.github.io/embodied-data-pyramid/)｜[repo](https://github.com/worldbench/awesome-embodied-data-pyramid)｜[arXiv](https://arxiv.org/abs/2607.24744v1)
 
-
-
 ### (3.6) 年度趋势总结
 
 - State of Robot Learning（Dec 2025）：[website](https://vedder.io/misc/state_of_robot_learning_dec_2025.html)
 - 许华哲 - 具身智能：2025 回望：[website](https://zhuanlan.zhihu.com/p/1983661736180589668)
 - 林天威 - 具身 VLA 的 2025：从 Demo 到通用的距离：[website](https://zhuanlan.zhihu.com/p/1989799567177307432)
-
-
 
 <a id="algorithm"></a>
 
@@ -375,8 +307,6 @@ WhynotTV、TianxingChen（陈天行）、穆尧_YaoMarkMu、许华哲 Harry、�
   - [(10.2) UAV —— 无人机](./topics/algorithm.md#uav)
   - [(10.3) Autonomous Driving —— 自动驾驶](./topics/algorithm.md#ad)
 
-
-
 <a id="infrastructure"></a>
 
 ## 🏋️‍♂️ (5) Infrastructure - 软件基础设施篇
@@ -389,8 +319,6 @@ WhynotTV、TianxingChen（陈天行）、穆尧_YaoMarkMu、许华哲 Harry、�
 - [(2) Benchmarks —— 基准集](./topics/infrastructure.md#benchmarks)
 - [(3) Datasets —— 数据集](./topics/infrastructure.md#datasets)
 - [(4) 工具链 —— 数据格式与策略部署](./topics/infrastructure.md#policy-serving)
-
-
 
 <a id="control"></a>
 
@@ -412,8 +340,6 @@ WhynotTV、TianxingChen（陈天行）、穆尧_YaoMarkMu、许华哲 Harry、�
   - [(3.3) 里程计与 SLAM](./topics/control.md#slam)
   - [(3.4) 工程生态与工具](./topics/control.md#engineering-stack)
 
-
-
 <a id="hardware"></a>
 
 ## 🦾 (7) Hardware - 硬件篇
@@ -434,8 +360,6 @@ WhynotTV、TianxingChen（陈天行）、穆尧_YaoMarkMu、许华哲 Harry、�
   - [(5.4) 传感器购买](./topics/hardware.md#tactile)
 - [(6) Data Collection —— 数据采集硬件](./topics/hardware.md#data_collection)
 - [(7) Companies —— 公司与硬件生态](./topics/hardware.md#companies)
-
-
 
 ## 🤝 Contributing - 参与贡献
 
@@ -460,8 +384,6 @@ WhynotTV、TianxingChen（陈天行）、穆尧_YaoMarkMu、许华哲 Harry、�
   url = {https://github.com/tianxingchen/Embodied-AI-Guide},
 }
 ```
-
-
 
 ## 🏷️ License - 许可协议
 

--- a/topics/algorithm.md
+++ b/topics/algorithm.md
@@ -202,7 +202,7 @@ VLA（Vision-Language-Action）可以理解为“把视觉-语言模型的能力
 
 ### (5.2) 分层双系统 VLA ⭐
 
-近一年一个非常强的范式是“分层双系统”：  
+2025 年起最有影响力的范式之一是“分层双系统”：  
 **System 2**（慢系统）负责理解与规划（通常是 VLM/LLM），输出语言/符号/latent 的中间表示；  
 **System 1**（快系统）负责高频、稳定的低层控制（VLA / policy），将中间表示转成连续动作。  
 它的直观优势是：在长任务与复杂场景中，把“推理/规划”与“高频控制”解耦，既提升可解释性，也更易做工程约束与安全策略。
@@ -232,7 +232,7 @@ VLA（Vision-Language-Action）可以理解为“把视觉-语言模型的能力
 ### (5.3) 2025 年代表工作
 
 <details>
-<summary><b>展开：2025 年以来的代表工作</b></summary>
+<summary><b>展开：2025 年代表工作列表</b></summary>
 
 | 工作 | 链接 | 机构 | 时间 | 备注 |
 |---|---|---|---|---|
@@ -264,7 +264,7 @@ VLA（Vision-Language-Action）可以理解为“把视觉-语言模型的能力
 | **VLA**（Vision-Language-Action） | 视觉 + 语言直接映射到动作 | 看一眼、听指令、直接动 | π0 / π0.5、GR00T N1 系列、RDT-1B、OpenVLA |
 | **VA**（Vision-Action） | 只吃视觉，不接受语言条件 | 任务固定时更轻、更快 | ACT、Diffusion Policy 及其变体 |
 | **WAM**（World-Action Model） | 先用世界模型预测「接下来会看到什么」，再从预测中解出动作 | 先在脑子里想一遍再动手 | 入门可先读上一节的 WorldVLA；此后出现了 FastWAM、X-WAM 等专做此事的一类 |
-| **记忆增强**（Memory-Augmented） | 在策略内部显式维护跨时刻的记忆 | 解决「我刚才把盖子放哪了」 | 这类任务的评测可看 RMBench 基准 |
+| **记忆增强**（Memory-Augmented） | 在策略内部显式维护跨时刻的记忆 | 解决「我刚才把盖子放哪了」 | π0.6-MEM / π0.7（见下文）；评测用 RMBench |
 
 还有一个和本体相关的常见缩写 **WBC**（Whole-Body Control，全身控制）：把控制目标从「机械臂末端」扩展到躯干、腿、头等整个身体，是人形机器人方向的主线之一，详见[控制篇](./control.md)。2026 年起也常见「全身智能」（Whole-Body Intelligence）这个说法，主要来自 Gemini Robotics 2 的表述，指的是让同一个策略同时管规划与全身运动，目前更多是产品叙事而非公认术语。
 
@@ -272,9 +272,9 @@ VLA（Vision-Language-Action）可以理解为“把视觉-语言模型的能力
 
 #### 四个正在发生的变化
 
-**(1) 从「只学演示」到「从经验里学」。** 纯模仿演示数据很容易停在「成功一半」的水平，再往上堆演示的边际收益迅速衰减。π\*0.6 提出的 [RECAP](https://arxiv.org/abs/2511.14759) 把演示、自主 rollout 与人工介入纠正混在一起做 RL（用 advantage 条件化绕开 flow matching 模型拿不到 action log-prob 的问题），在叠衣服、组装纸箱、做咖啡这类长任务上把吞吐翻倍、失败率减半。**RL 后训练正在从加分项变成必选项**，国内工作里 Hy-VLA 的 [FlowPRO](https://wuyeyexvnainai.github.io/flowpro/) 偏好优化、LingBot-VLA 的 RL 后训练都是同一思路。
+**(1) 从「只学演示」到「从经验里学」。** 纯模仿演示数据很容易停在「成功一半」的水平，再往上堆演示的边际收益迅速衰减。π\*0.6 提出的 [RECAP](https://arxiv.org/abs/2511.14759) 把演示、自主 rollout 与人工介入纠正混在一起做 RL（用 advantage 条件化绕开 flow matching 模型拿不到 action log-prob 的问题），在叠衣服、组装纸箱、做咖啡这类长任务上把吞吐翻倍、失败率减半。**RL 后训练正在从加分项变成必选项**，国内工作里 Hy-Embodied-0.5-VLA 的 [FlowPRO](https://wuyeyexvnainai.github.io/flowpro/) 偏好优化、LingBot-VLA 的 RL 后训练都是同一思路。
 
-**(2) 记忆从可选模块变成架构的一部分。** 长任务里「刚才把盖子放哪了」是硬需求。π0.6-MEM 与 [π0.7](https://arxiv.org/abs/2604.15483) 把记忆系统直接做进主干（对历史帧做时空压缩后输出固定数量 token），Hy-VLA 也带了多帧历史的紧凑记忆编码器。评测侧有 [RMBench](https://rmbench.github.io/) 专测记忆依赖任务。
+**(2) 记忆从可选模块变成架构的一部分。** 长任务里「刚才把盖子放哪了」是硬需求。π0.6-MEM 与 [π0.7](https://arxiv.org/abs/2604.15483) 把记忆系统直接做进主干（对历史帧做时空压缩后输出固定数量 token），Hy-Embodied-0.5-VLA 也带了多帧历史的紧凑记忆编码器。评测侧有 [RMBench](https://rmbench.github.io/) 专测记忆依赖任务。
 
 **(3) 世界模型进入推理链路。** 不再是「另做一个世界模型」，而是把未来预测嵌进策略内部：[InternVLA-A1.5](https://arxiv.org/abs/2607.04988) 用可学习的 foresight token 去查询未来动态、训练时由一个冻结的视频生成模型监督，推理时把视频分支丢掉以控制延迟；NVIDIA 的 GR00T N2 则直接建在 DreamZero 这套 World-Action Model 框架上。
 
@@ -282,7 +282,7 @@ VLA（Vision-Language-Action）可以理解为“把视觉-语言模型的能力
 
 > 顺着这四条看，会发现**竞争焦点已经从「架构」转向「数据配方 + 评测」**。2026 年那篇[数据视角的 VLA 综述](https://arxiv.org/abs/2604.23001)把这点讲得很直接：未来的进展更多取决于数据引擎与评测协议的协同设计，而不是模型架构，因此应当把数据基础设施当作一等研究问题。
 
-#### 2026 代表工作
+#### 代表工作（2025 末 — 2026）
 
 | 工作 | 链接 | 机构 | 时间 | 一句话看点 |
 |---|---|---|---|---|

--- a/topics/algorithm.md
+++ b/topics/algorithm.md
@@ -88,7 +88,7 @@ Vision Foundation Models 的核心价值不在于“替代控制”，而在于*
 | MPC 入门 | 华工机器人实验室：MPC 从公式到代码 | bilibili：[link](https://www.bilibili.com/video/BV1U54y1J7wh) / 代码：[link](https://gitee.com/clangwu/mpc_control.git) | 从 PID 过渡到 MPC，含仿真与代码 |
 | RL 入门 | 强化学习的数学原理（西湖大学） | bilibili：[link](https://space.bilibili.com/2044042934/channel/collectiondetail?sid=748665) / 书+代码：[link](https://github.com/MathFoundationRL/Book-Mathematical-Foundation-of-Reinforcement-Learning) | 数学推导体系化，适合打地基 |
 | DRL 速览 | Abbeel 6 Lectures | [link](https://www.youtube.com/watch?v=2GwBez0D20A) | 六讲概览 DRL，快速建立框架 |
-| DRL 系统课 | Berkeley CS285 | 网站：[link](https://rail.eecs.berkeley.edu/deeprlcourse/) / YouTube：[link](https://www.youtube.com/playlist?list=PL_iWQOsE6TfVYGEGiAOMaOzzv41Jfm_Ps) | Levine 主讲，内容详尽 |
+| DRL 系统课 | Berkeley CS 185/285（原 CS285） | 网站：[link](https://rail.eecs.berkeley.edu/deeprlcourse/) / YouTube：[link](https://www.youtube.com/playlist?list=PL_iWQOsE6TfVYGEGiAOMaOzzv41Jfm_Ps) | Levine 主讲，内容详尽 |
 | DRL 中文课 | 李宏毅强化学习 | [link](https://www.bilibili.com/video/BV1XP4y1d7Bk) | 搭配实践（Gymnasium 等）较友好 |
 | 模仿学习 | LAMDA：IL 简洁教程 | [link](https://www.lamda.nju.edu.cn/xut/Imitation_Learning.pdf) | 结构清晰，入门友好 |
 | 真实机器人 IL | RSS 2024 Workshop 教程 | [link](https://www.bilibili.com/video/BV1Fx4y1s7if) | 从真实机器人监督学习的角度讲落地问题 |
@@ -199,7 +199,7 @@ VLA（Vision-Language-Action）可以理解为“把视觉-语言模型的能力
 
 </details>
 
-### (5.2) 分层双系统 VLA（2025.05 更新）⭐
+### (5.2) 分层双系统 VLA ⭐
 
 近一年一个非常强的范式是“分层双系统”：  
 **System 2**（慢系统）负责理解与规划（通常是 VLM/LLM），输出语言/符号/latent 的中间表示；  
@@ -226,8 +226,9 @@ VLA（Vision-Language-Action）可以理解为“把视觉-语言模型的能力
 | Psi-R1（灵初智能） | [link](https://www.jiqizhixin.com/articles/2025-03-03-9) | 2025.04.27 | 分层端到端 VLA + RL，test-time scaling |
 | Gemini Robotics | [link](https://arxiv.org/pdf/2503.20020) | 2025.03.25 | 50 Hz |
 | Gemini Robotics on-device | [link](https://deepmind.google/discover/blog/gemini-robotics-on-device-brings-ai-to-local-robotic-devices/) | 2025.06.24 | 设备端部署导向 |
+| Gemini Robotics（系列入口） | [link](https://deepmind.google/models/gemini-robotics/) | 滚动更新 | 后续版本转向全身智能（Whole-Body Intelligence） |
 
-### (5.3) 最新 VLA 工作（滚动更新）
+### (5.3) 2025 年代表工作
 
 <details>
 <summary><b>展开：2025 年以来的代表工作</b></summary>
@@ -253,8 +254,27 @@ VLA（Vision-Language-Action）可以理解为“把视觉-语言模型的能力
 
 </details>
 
+### (5.4) 2026 年的图景：VLA 只是其中一类
+
+前面几节的工作几乎都叫「某某 VLA」。但到 2026 年，动作模型的形态已经不止这一种，读论文时会频繁碰到几个新缩写。按**动作是怎么生成的**来分，大致是这几类：
+
+| 家族 | 动作从哪来 | 直观理解 | 代表工作 |
+|---|---|---|---|
+| **VLA**（Vision-Language-Action） | 视觉 + 语言直接映射到动作 | 看一眼、听指令、直接动 | π0 / π0.5、GR00T N1 系列、RDT-1B、OpenVLA |
+| **VA**（Vision-Action） | 只吃视觉，不接受语言条件 | 任务固定时更轻、更快 | ACT、Diffusion Policy 及其变体 |
+| **WAM**（World-Action Model） | 先用世界模型预测「接下来会看到什么」，再从预测中解出动作 | 先在脑子里想一遍再动手 | 入门可先读上一节的 WorldVLA；此后出现了 FastWAM、X-WAM 等专做此事的一类 |
+| **记忆增强**（Memory-Augmented） | 在策略内部显式维护跨时刻的记忆 | 解决「我刚才把盖子放哪了」 | 这类任务的评测可看 RMBench 基准 |
+
+还有一组和本体相关的缩写：**WBC**（Whole-Body Control，全身控制）与 **WBI**（Whole-Body Intelligence，全身智能），指把控制目标从「机械臂末端」扩展到躯干、腿、头等整个身体，是人形机器人方向的主线之一，详见[控制篇](./control.md)。
+
+**这几个家族并不互斥。** 实际论文里经常是叠加的——一个模型可以既是 VLA、又带世界模型预测、还加了记忆模块。所以看到新工作时，比记住它叫什么更有用的是问三个问题：**动作表示是什么**（连续回归 / 离散 token / 扩散）、**条件里有没有语言**、**有没有显式预测未来**。这三条基本就能定位它在上面这张表里的位置，也是复现时最先要搞清楚的三件事。
+
+> 🌱 **新手建议**：不要一上来就横向啃十几个 foundation model。更快的路径是先拿 ACT 或 Diffusion Policy 这类结构简单的基线，把「采数据 → 训练 → 在仿真里评测」这条链路完整跑通一遍（可以直接用主页第 2 章的实战教程），先建立起对数据格式、动作维度、评测指标的手感，再回头读 π0、GR00T 这类大模型的论文，会清楚很多。
+
+**去哪找可运行的实现？** 这些模型的开源实现比较分散，两个地方能省不少事：[LeRobot](https://github.com/huggingface/lerobot) 提供了统一的数据集格式和多个策略的训练代码，它的数据格式目前基本是通用底座；[XPolicyLab](https://github.com/XPolicyLab/XPolicyLab) 把数十个策略收敛到了同一套部署接口，适合需要在同一批任务上横向对比多个模型的场景。
+
 **小结**：  
-VLA 的研究正在从“把动作 token 化”走向“更可控、更可部署、更长程”的系统形态：分层架构、world model、3D 表征与安全对齐都在加速融合。做项目时建议优先关注动作表示与数据配方，它们往往比换 backbone 更影响最终表现。
+VLA 的研究正在从「把动作 token 化」走向「更可控、更可部署、更长程」的系统形态：分层架构、world model、3D 表征与安全对齐都在加速融合。一个值得注意的趋势是，随着公开基准和统一评测流程变多，靠换 backbone 刷点的空间在收窄，**数据配方与动作表示**反而成了更关键的变量。做项目时建议优先关注这两件事，它们往往比换一个更大的 backbone 更影响最终表现。
 
 <section id="cv"></section>
 
@@ -272,14 +292,14 @@ VLA 的研究正在从“把动作 token 化”走向“更可控、更可部署
 
 | 层级 | 关注点（具身视角） | 代表资源 | 链接 |
 |---|---|---|---|
-| 2D Vision | 稳定表征与泛化：backbone、对比学习、生成式表征 | CNN 概念 / ResNet / ViT / Swin | CNN：[link](https://easyai.tech/ai-definition/cnn/；ResNet：https://www.bilibili.com/video/BV1P3411y7nn；ViT：https://www.bilibili.com/video/BV15P4y137jb；Swin：https://www.bilibili.com/video/BV13L4y1475U) |
+| 2D Vision | 稳定表征与泛化：backbone、对比学习、生成式表征 | CNN 概念 / ResNet / ViT / Swin | CNN：[link](https://easyai.tech/ai-definition/cnn/)｜ResNet：[link](https://www.bilibili.com/video/BV1P3411y7nn)｜ViT：[link](https://www.bilibili.com/video/BV15P4y137jb)｜Swin：[link](https://www.bilibili.com/video/BV13L4y1475U) |
 | 2D Vision | 表征学习方法论：对比学习与大规模预训练 | 对比学习综述 | [link](https://www.bilibili.com/video/BV19S4y1M7hm) |
-| 2D/4D Gen | 生成式模型（用于表征、合成数据、目标图像等） | 自回归综述 / 扩散综述 / 扩散推导 | 自回归：[link](https://arxiv.org/pdf/2411.05902；扩散：https://arxiv.org/pdf/2209.00796；推导：https://kexue.fm/archives/9119) |
+| 2D/4D Gen | 生成式模型（用于表征、合成数据、目标图像等） | 自回归综述 / 扩散综述 / 扩散推导 | 自回归：[link](https://arxiv.org/pdf/2411.05902)｜扩散：[link](https://arxiv.org/pdf/2209.00796)｜推导：[link](https://kexue.fm/archives/9119) |
 | 3D Vision | 多视几何与三维理解（对重建/位姿/点云感知很关键） | Andreas Geiger 3D Vision | [link](https://uni-tuebingen.de/fakultaeten/mathematisch-naturwissenschaftliche-fakultaet/fachbereiche/informatik/lehrstuehle/autonomous-vision/lectures/computer-vision/) |
 | 3D Vision | 三维重建与理解（偏工程与应用） | GAMES203 | [link](https://www.bilibili.com/video/BV1pw411d7aS) |
-| 3D/Gen | 2D/3D 生成方向梳理 | 论文分类 / 2024 论文整理 | 分类：[link](https://zhuanlan.zhihu.com/p/617510702；2024：https://zhuanlan.zhihu.com/p/700895749) |
-| 4D Vision | 视频理解：时序建模与跨帧一致性（具身中非常常见） | 开山之作 / 串讲 / 综述 | 开山：[link](https://www.bilibili.com/video/BV1mq4y1x7RU；串讲：https://www.bilibili.com/video/BV1fL4y157yA；综述：https://arxiv.org/pdf/2312.17432) |
-| 4D Gen | 视频/4D 生成（用于合成与世界建模相关） | Lilian Weng 视频扩散博客 / 4D generation list | 博客：[link](https://lilianweng.github.io/posts/2024-04-12-diffusion-video/；list：https://github.com/cwchenwang/awesome-4d-generation) |
+| 3D/Gen | 2D/3D 生成方向梳理 | 论文分类 / 2024 论文整理 | 分类：[link](https://zhuanlan.zhihu.com/p/617510702)｜2024：[link](https://zhuanlan.zhihu.com/p/700895749) |
+| 4D Vision | 视频理解：时序建模与跨帧一致性（具身中非常常见） | 开山之作 / 串讲 / 综述 | 开山：[link](https://www.bilibili.com/video/BV1mq4y1x7RU)｜串讲：[link](https://www.bilibili.com/video/BV1fL4y157yA)｜综述：[link](https://arxiv.org/pdf/2312.17432) |
+| 4D Gen | 视频/4D 生成（用于合成与世界建模相关） | Lilian Weng 视频扩散博客 / 4D generation list | 博客：[link](https://lilianweng.github.io/posts/2024-04-12-diffusion-video/)｜list：[link](https://github.com/cwchenwang/awesome-4d-generation) |
 
 ### (6.2) Visual Prompting & Affordance Grounding
 

--- a/topics/algorithm.md
+++ b/topics/algorithm.md
@@ -162,6 +162,7 @@ VLA（Vision-Language-Action）可以理解为“把视觉-语言模型的能力
 |---|---|---|---|
 | Blog | 具身智能 Vision-Language-Action 的思考 | [link](https://zhuanlan.zhihu.com/p/9880769870) |  |
 | Blog | 具身智能 VLA 的思考（问答） | [link](https://www.zhihu.com/question/655570660/answer/87040917575) |  |
+| Survey | 数据视角：数据集、基准与数据引擎 ⭐ | [link](https://arxiv.org/abs/2604.23001) / [repo](https://github.com/ziyaow1010/vla-datasets-benchmarks) | 2026.04；持续更新，论证「数据基础设施才是瓶颈」 |
 | Survey | Action Tokenization 视角 VLA Survey | [link](https://arxiv.org/abs/2507.01925) / [link](https://github.com/Psi-Robot/Awesome-VLA-Papers) | 2025.07.02 |
 | Survey | VLA for Embodied AI Survey | [link](https://arxiv.org/abs/2405.14093) | 2024.11.28 |
 
@@ -254,7 +255,7 @@ VLA（Vision-Language-Action）可以理解为“把视觉-语言模型的能力
 
 </details>
 
-### (5.4) 2026 年的图景：VLA 只是其中一类
+### (5.4) 2026 进展 ⭐
 
 前面几节的工作几乎都叫「某某 VLA」。但到 2026 年，动作模型的形态已经不止这一种，读论文时会频繁碰到几个新缩写。按**动作是怎么生成的**来分，大致是这几类：
 
@@ -269,12 +270,44 @@ VLA（Vision-Language-Action）可以理解为“把视觉-语言模型的能力
 
 **这几个家族并不互斥。** 实际论文里经常是叠加的——一个模型可以既是 VLA、又带世界模型预测、还加了记忆模块。所以看到新工作时，比记住它叫什么更有用的是问三个问题：**动作表示是什么**（连续回归 / 离散 token / 扩散）、**条件里有没有语言**、**有没有显式预测未来**。这三条基本就能定位它在上面这张表里的位置，也是复现时最先要搞清楚的三件事。
 
+#### 四个正在发生的变化
+
+**(1) 从「只学演示」到「从经验里学」。** 纯模仿演示数据很容易停在「成功一半」的水平，再往上堆演示的边际收益迅速衰减。π\*0.6 提出的 [RECAP](https://arxiv.org/abs/2511.14759) 把演示、自主 rollout 与人工介入纠正混在一起做 RL（用 advantage 条件化绕开 flow matching 模型拿不到 action log-prob 的问题），在叠衣服、组装纸箱、做咖啡这类长任务上把吞吐翻倍、失败率减半。**RL 后训练正在从加分项变成必选项**，国内工作里 Hy-VLA 的 [FlowPRO](https://wuyeyexvnainai.github.io/flowpro/) 偏好优化、LingBot-VLA 的 RL 后训练都是同一思路。
+
+**(2) 记忆从可选模块变成架构的一部分。** 长任务里「刚才把盖子放哪了」是硬需求。π0.6-MEM 与 [π0.7](https://arxiv.org/abs/2604.15483) 把记忆系统直接做进主干（对历史帧做时空压缩后输出固定数量 token），Hy-VLA 也带了多帧历史的紧凑记忆编码器。评测侧有 [RMBench](https://rmbench.github.io/) 专测记忆依赖任务。
+
+**(3) 世界模型进入推理链路。** 不再是「另做一个世界模型」，而是把未来预测嵌进策略内部：[InternVLA-A1.5](https://arxiv.org/abs/2607.04988) 用可学习的 foresight token 去查询未来动态、训练时由一个冻结的视频生成模型监督，推理时把视频分支丢掉以控制延迟；NVIDIA 的 GR00T N2 则直接建在 DreamZero 这套 World-Action Model 框架上。
+
+**(4) 从桌面延伸到全身。** [Gemini Robotics 2](https://deepmind.google/blog/gemini-robotics-2-brings-whole-body-intelligence-to-robots/)（2026.07）是个明确的分水岭：此前几代基本是「上半身 / 桌面」模型，这一代开始控制完整人形——从脚到指尖，配套还拆成了三个模型（VLA 负责运动控制、ER 2 负责具身推理与多机协同、On-Device 2 负责本地部署）。
+
+> 顺着这四条看，会发现**竞争焦点已经从「架构」转向「数据配方 + 评测」**。2026 年那篇[数据视角的 VLA 综述](https://arxiv.org/abs/2604.23001)把这点讲得很直接：未来的进展更多取决于数据引擎与评测协议的协同设计，而不是模型架构，因此应当把数据基础设施当作一等研究问题。
+
+#### 2026 代表工作
+
+| 工作 | 链接 | 机构 | 时间 | 一句话看点 |
+|---|---|---|---|---|
+| VLAct | [paper](https://arxiv.org/abs/2608.27550) / [repo](https://github.com/starVLA/VLAct) / [主页](https://starvla.github.io/VLAct/) | 港中文 / 思谋等 | 2026.08 | 表征驱动的继续预训练；只用开源数据做出可复用动作主干 |
+| Gemini Robotics 2 | [blog](https://deepmind.google/blog/gemini-robotics-2-brings-whole-body-intelligence-to-robots/) | Google DeepMind | 2026.07 | 全身智能；VLA / ER / On-Device 三模型分工 |
+| InternVLA-A1.5 | [paper](https://arxiv.org/abs/2607.04988) / [repo](https://github.com/InternRobotics/InternVLA-A-series) | 上海 AI Lab | 2026.07 | foresight token 查询未来动态，由视频生成模型监督 |
+| Hy-Embodied-0.5-VLA | [paper](https://arxiv.org/abs/2606.14409) / [repo](https://github.com/Tencent-Hunyuan/Hy-Embodied-0.5-VLA) | 腾讯混元 | 2026.06 | 万小时级 UMI 数据 + 记忆编码器 + RL 后训练的完整栈 |
+| π0.7 | [paper](https://arxiv.org/abs/2604.15483) | Physical Intelligence | 2026.04 | 可操控的通用基座；记忆 + 多模态上下文条件 |
+| Xiaomi-Robotics-0 | [paper](https://arxiv.org/abs/2602.12684) / [repo](https://github.com/XiaomiRobotics/Xiaomi-Robotics-0) | 小米 | 2026.02 | 4.7B，面向实时执行；权重与后训练代码开源 |
+| LingBot-VLA | [paper](https://arxiv.org/abs/2601.18692) / [repo](https://github.com/Robbyant/lingbot-vla) | 蚂蚁灵波 | 2026.01 | 两万小时多构型真机预训练；配套开源 GM-100 基准 |
+| UnifoLM-VLA-0 | [repo](https://github.com/unitreerobotics/unifolm-vla) | 宇树科技 | 2026.01 | 面向人形操作；强化空间语义的继续预训练 |
+| InternVLA-A1 | [paper](https://arxiv.org/abs/2601.02456) / [repo](https://github.com/InternRobotics/InternVLA-A-series) | 上海 AI Lab | 2026.01 | 把未来视觉状态与动作作为联合训练目标 |
+| π\*0.6（RECAP） | [paper](https://arxiv.org/abs/2511.14759) / [blog](https://www.pi.website/blog/pistar06) | Physical Intelligence | 2025.11 | 演示 + 自主经验 + 人工纠正混合 RL，吞吐翻倍 |
+| GR00T N1.7 / N2 | [repo](https://github.com/NVIDIA/Isaac-GR00T) | NVIDIA | 2026 | N1.7 已商用早期接入；N2 转向 World-Action Model 架构 |
+
+#### 评测正在变严
+
+一个容易忽略但很实际的变化：**老基准开始饱和、且有记忆效应**，光看 LIBERO 的数字已经不足以说明问题。因此出现了两类补充手段——一是更抗「刷分」的仿真基准（LIBERO-Plus、VLA-Arena、[RoboDojo](https://robodojo-benchmark.com/leaderboard)），二是真机分布式评测：[RoboArena](https://robo-arena.github.io/)（[论文](https://arxiv.org/abs/2506.18123)）不再统一任务，而是让分布在多所机构的评测者自选场景、对策略做双盲两两对比，再聚合成排名。自己做实验时，**至少报一个仿真基准 + 一个真机或第三方榜单**会比只报单一数字可信得多。
+
 > 🌱 **新手建议**：不要一上来就横向啃十几个 foundation model。更快的路径是先拿 ACT 或 Diffusion Policy 这类结构简单的基线，把「采数据 → 训练 → 在仿真里评测」这条链路完整跑通一遍（可以直接用主页第 2 章的实战教程），先建立起对数据格式、动作维度、评测指标的手感，再回头读 π0、GR00T 这类大模型的论文，会清楚很多。
 
 **去哪找可运行的实现？** 这些模型的开源实现比较分散，两个地方能省不少事：[LeRobot](https://github.com/huggingface/lerobot) 提供了统一的数据集格式和多个策略的训练代码，它的数据格式目前基本是通用底座；[XPolicyLab](https://github.com/XPolicyLab/XPolicyLab) 把数十个策略收敛到了同一套部署接口，适合需要在同一批任务上横向对比多个模型的场景。
 
 **小结**：  
-VLA 的研究正在从「把动作 token 化」走向「更可控、更可部署、更长程」的系统形态：分层架构、world model、3D 表征与安全对齐都在加速融合。一个值得注意的趋势是，随着公开基准和统一评测流程变多，靠换 backbone 刷点的空间在收窄，**数据配方与动作表示**反而成了更关键的变量。做项目时建议优先关注这两件事，它们往往比换一个更大的 backbone 更影响最终表现。
+VLA 从「把动作 token 化」一路走到了「能从自己的失败里改进」。如果只记一句话：**2026 年拉开差距的不是 backbone，而是数据配方、RL 后训练与评测的可信度**。落到做项目上，优先级大致是——先用 ACT / DP 跑通全链路，再挑一个开源基座（π 系列、GR00T、InternVLA-A 系列都有可用权重）做微调，然后把力气花在数据质量和一个诚实的评测协议上，而不是换更大的模型。
 
 <section id="cv"></section>
 

--- a/topics/algorithm.md
+++ b/topics/algorithm.md
@@ -227,7 +227,7 @@ VLA（Vision-Language-Action）可以理解为“把视觉-语言模型的能力
 | Psi-R1（灵初智能） | [link](https://www.jiqizhixin.com/articles/2025-03-03-9) | 2025.04.27 | 分层端到端 VLA + RL，test-time scaling |
 | Gemini Robotics | [link](https://arxiv.org/pdf/2503.20020) | 2025.03.25 | 50 Hz |
 | Gemini Robotics on-device | [link](https://deepmind.google/discover/blog/gemini-robotics-on-device-brings-ai-to-local-robotic-devices/) | 2025.06.24 | 设备端部署导向 |
-| Gemini Robotics（系列入口） | [link](https://deepmind.google/models/gemini-robotics/) | 滚动更新 | 后续版本转向全身智能（Whole-Body Intelligence） |
+| Gemini Robotics（系列入口） | [link](https://deepmind.google/models/gemini-robotics/) | 滚动更新 | 最新一代见 (5.4) 的 Gemini Robotics 2 |
 
 ### (5.3) 2025 年代表工作
 
@@ -266,7 +266,7 @@ VLA（Vision-Language-Action）可以理解为“把视觉-语言模型的能力
 | **WAM**（World-Action Model） | 先用世界模型预测「接下来会看到什么」，再从预测中解出动作 | 先在脑子里想一遍再动手 | 入门可先读上一节的 WorldVLA；此后出现了 FastWAM、X-WAM 等专做此事的一类 |
 | **记忆增强**（Memory-Augmented） | 在策略内部显式维护跨时刻的记忆 | 解决「我刚才把盖子放哪了」 | 这类任务的评测可看 RMBench 基准 |
 
-还有一组和本体相关的缩写：**WBC**（Whole-Body Control，全身控制）与 **WBI**（Whole-Body Intelligence，全身智能），指把控制目标从「机械臂末端」扩展到躯干、腿、头等整个身体，是人形机器人方向的主线之一，详见[控制篇](./control.md)。
+还有一个和本体相关的常见缩写 **WBC**（Whole-Body Control，全身控制）：把控制目标从「机械臂末端」扩展到躯干、腿、头等整个身体，是人形机器人方向的主线之一，详见[控制篇](./control.md)。2026 年起也常见「全身智能」（Whole-Body Intelligence）这个说法，主要来自 Gemini Robotics 2 的表述，指的是让同一个策略同时管规划与全身运动，目前更多是产品叙事而非公认术语。
 
 **这几个家族并不互斥。** 实际论文里经常是叠加的——一个模型可以既是 VLA、又带世界模型预测、还加了记忆模块。所以看到新工作时，比记住它叫什么更有用的是问三个问题：**动作表示是什么**（连续回归 / 离散 token / 扩散）、**条件里有没有语言**、**有没有显式预测未来**。这三条基本就能定位它在上面这张表里的位置，也是复现时最先要搞清楚的三件事。
 
@@ -286,7 +286,7 @@ VLA（Vision-Language-Action）可以理解为“把视觉-语言模型的能力
 
 | 工作 | 链接 | 机构 | 时间 | 一句话看点 |
 |---|---|---|---|---|
-| VLAct | [paper](https://arxiv.org/abs/2608.27550) / [repo](https://github.com/starVLA/VLAct) / [主页](https://starvla.github.io/VLAct/) | 港中文 / 思谋等 | 2026.08 | 表征驱动的继续预训练；只用开源数据做出可复用动作主干 |
+| VLAct | [paper](https://arxiv.org/abs/2608.27550) / [repo](https://github.com/starVLA/VLAct) / [主页](https://starvla.github.io/VLAct/) | 港中文 / 港科大 / 思谋 | 2026.08 | 表征驱动的继续预训练；只用开源数据 + 16 卡做出可复用动作主干 |
 | Gemini Robotics 2 | [blog](https://deepmind.google/blog/gemini-robotics-2-brings-whole-body-intelligence-to-robots/) | Google DeepMind | 2026.07 | 全身智能；VLA / ER / On-Device 三模型分工 |
 | InternVLA-A1.5 | [paper](https://arxiv.org/abs/2607.04988) / [repo](https://github.com/InternRobotics/InternVLA-A-series) | 上海 AI Lab | 2026.07 | foresight token 查询未来动态，由视频生成模型监督 |
 | Hy-Embodied-0.5-VLA | [paper](https://arxiv.org/abs/2606.14409) / [repo](https://github.com/Tencent-Hunyuan/Hy-Embodied-0.5-VLA) | 腾讯混元 | 2026.06 | 万小时级 UMI 数据 + 记忆编码器 + RL 后训练的完整栈 |
@@ -300,7 +300,7 @@ VLA（Vision-Language-Action）可以理解为“把视觉-语言模型的能力
 
 #### 评测正在变严
 
-一个容易忽略但很实际的变化：**老基准开始饱和、且有记忆效应**，光看 LIBERO 的数字已经不足以说明问题。因此出现了两类补充手段——一是更抗「刷分」的仿真基准（LIBERO-Plus、VLA-Arena、[RoboDojo](https://robodojo-benchmark.com/leaderboard)），二是真机分布式评测：[RoboArena](https://robo-arena.github.io/)（[论文](https://arxiv.org/abs/2506.18123)）不再统一任务，而是让分布在多所机构的评测者自选场景、对策略做双盲两两对比，再聚合成排名。自己做实验时，**至少报一个仿真基准 + 一个真机或第三方榜单**会比只报单一数字可信得多。
+一个容易忽略但很实际的变化：**老基准开始饱和、且有记忆效应**，光看 LIBERO 的数字已经不足以说明问题。因此出现了两类补充手段——一是更抗「刷分」的仿真基准（[LIBERO-Plus](https://arxiv.org/abs/2510.13626) 用七类扰动把 LIBERO 扩成一万多个任务并分五档难度、[VLA-Arena](https://arxiv.org/abs/2512.22539) 补上动态场景与安全约束、[RoboDojo](https://robodojo-benchmark.com/leaderboard)），二是真机分布式评测：[RoboArena](https://robo-arena.github.io/)（[论文](https://arxiv.org/abs/2506.18123)）不再统一任务，而是让分布在多所机构的评测者自选场景、对策略做双盲两两对比，再聚合成排名。自己做实验时，**至少报一个仿真基准 + 一个真机或第三方榜单**会比只报单一数字可信得多。
 
 > 🌱 **新手建议**：不要一上来就横向啃十几个 foundation model。更快的路径是先拿 ACT 或 Diffusion Policy 这类结构简单的基线，把「采数据 → 训练 → 在仿真里评测」这条链路完整跑通一遍（可以直接用主页第 2 章的实战教程），先建立起对数据格式、动作维度、评测指标的手感，再回头读 π0、GR00T 这类大模型的论文，会清楚很多。
 

--- a/topics/control.md
+++ b/topics/control.md
@@ -2,12 +2,16 @@
 
 > 这一章并不是为了让你“立刻跑一个模型”，而是为具身智能系统提供**稳定性、可解释性与工程底座**。控制论保证系统在高频下不崩溃，机器人学提供几何与动力学约束，SLAM 与状态估计让机器人“知道自己在哪里”，ROS 与工程库则把理论变成可复现的系统。
 
+<section id="control-robotics"></section>
+
 ## (1) Control and Robotics —— 控制论与机器人学基础
 
 这一章覆盖的是具身智能中**最底层、也最容易被跳过的能力层**。  
 控制与机器人学本身并不会直接提高 benchmark 分数，但它们决定了系统是否**稳定、可解释、可调试、可部署**。如果说算法篇解决的是“我想让机器人做什么”，那么这一章回答的是：机器人**凭什么**能连续、安全、可控地做到。
 
 ---
+
+<section id="control-courses"></section>
 
 ### (1.1) 经典课程
 
@@ -23,10 +27,14 @@
 
 ---
 
+<section id="control-foundations"></section>
+
 ## (2) 控制理论基础（Control Foundations）
 
 控制论的目标不是“聪明”，而是**稳定、可预测与可调试**。  
 在具身系统中，学习策略通常建立在控制系统之上：控制负责高频稳定，学习负责复杂决策。
+
+<section id="classical-control"></section>
 
 ### (2.1) 经典控制（Classical Control）
 
@@ -37,6 +45,8 @@
 在真实机器人调试中，PID 往往是你**第一个、也是最常用的工具**。
 
 ---
+
+<section id="modern-control"></section>
 
 ### (2.2) 现代控制（线性系统与最优控制）
 
@@ -50,6 +60,8 @@ Website：[link](https://optimalcontrol.ri.cmu.edu/)，YouTube：[link](https://
 
 ---
 
+<section id="advanced-control"></section>
+
 ### (2.3) 先进控制（Advanced Control）
 
 在操作与交互任务中，以下方法尤为关键：鲁棒控制（应对模型不准）、阻抗/导纳/力位混合控制（[link](https://blog.csdn.net/a735148617/article/details/108564836)）、模型预测控制（MPC）以及基于学习的控制方法。
@@ -58,9 +70,13 @@ Website：[link](https://optimalcontrol.ri.cmu.edu/)，YouTube：[link](https://
 
 ---
 
+<section id="robotics-foundations"></section>
+
 ## (3) 机器人学导论（Robotics Foundations）
 
 机器人学解决的是“**几何 + 物理 + 结构**”问题，是控制与感知能够落地的前提。
+
+<section id="robotics-books"></section>
 
 ### (3.1) 推荐教材与材料
 
@@ -69,6 +85,8 @@ Website：[link](https://optimalcontrol.ri.cmu.edu/)，YouTube：[link](https://
 以及《现代机器人学：机构、规划与控制》（Kevin Lynch）、《机构学与机器人学的几何基础与旋量代数》（戴建生）、《机器人学的现代数学理论基础》（丁希仑）。
 
 ---
+
+<section id="kinematics-dynamics"></section>
 
 ### (3.2) 运动学与动力学（Kinematics & Dynamics）
 
@@ -86,6 +104,8 @@ IK 理论参考：[link](https://motion.cs.illinois.edu/RoboticSystems/InverseKi
 
 ---
 
+<section id="slam"></section>
+
 ### (3.3) 里程计与 SLAM（State Estimation）
 
 状态估计决定了机器人是否“知道自己在哪里”。  
@@ -98,6 +118,8 @@ SLAM 进一步将定位与建图结合，推荐参考：
 SLAM Handbook：[link](https://github.com/SLAM-Handbook-contributors/slam-handbook-public-release)，经典综述：[link](https://arxiv.org/abs/1606.05830)，《视觉 SLAM 十四讲》：[link](https://github.com/gaoxiang12/slambook2)，以及端到端方法 DROID-SLAM：[link](https://arxiv.org/abs/2108.10869)。
 
 ---
+
+<section id="engineering-stack"></section>
 
 ### (3.4) 工程生态与工具（Engineering Stack）
 

--- a/topics/hardware.md
+++ b/topics/hardware.md
@@ -134,9 +134,9 @@
 
 | 公司 | 主营产品 | Others |
 |---|---|---|
-| [松灵 AgileX](https://www.agilex.ai/) | [pipper 六轴机械臂](https://www.agilex.ai/chassis/16)<br>[PIKA 数采方案](https://www.agilex.ai/chassis/22)<br>[Cobot Magic 双臂遥操作平台](https://www.agilex.ai/chassis/27)<br>移动底盘 | 面向教育科研 |
+| [松灵 AgileX](https://www.agilex.ai/) | [PIPER 六轴机械臂](https://global.agilex.ai/products/piper)<br>[PIKA 数采方案](https://global.agilex.ai/products/pika)<br>[Cobot Magic 双臂遥操作平台](https://global.agilex.ai/products/cobot-magic)<br>[移动底盘系列](https://global.agilex.ai/collections/all) | 面向教育科研；[开源仓库](https://github.com/agilexrobotics) |
 | [宇树 Unitree](https://www.unitree.com/cn) | [四足机器人开发指南](https://www.yuque.com/ironfatty/nly1un/luo9gb)<br>[Go2 机器狗](https://www.unitree.com/cn/go2)<br>[AlienGo 机器狗](https://www.yuque.com/ironfatty/nly1un/dqcz3u)<br>[通用人形 H1](https://www.unitree.com/cn/h1)<br>[通用人形 G1](https://www.unitree.com/cn/g1) | 许多产出使用宇树的机器人作为硬件基础 |
-| [方舟无限 ARX](https://www.arx-x.com/?product/) | [X5 机械臂](https://www.arx-x.com/?product/21.html)<br>[X7 双臂平台](https://www.arx-x.com/?product/23.html)<br>[R5 机械臂](https://www.arx-x.com/?product/22.html) | 适合复现很多经典工作，例如 [aloha](https://mobile-aloha.github.io/cn.html)<br>[RoboTwin 松灵底盘 + 方舟臂](https://github.com/TianxingChen/RoboTwi) |
+| [方舟无限 ARX](https://www.arx-x.com/?product/) | [X5 机械臂](https://www.arx-x.com/?product/21.html)<br>[X7 双臂平台](https://www.arx-x.com/?product/23.html)<br>[R5 机械臂](https://www.arx-x.com/?product/22.html) | 适合复现很多经典工作，例如 [aloha](https://mobile-aloha.github.io/cn.html)<br>[RoboTwin 松灵底盘 + 方舟臂](https://github.com/RoboTwin-Platform/RoboTwin) |
 | [波士顿动力 Boston Dynamics](https://bostondynamics.com/) | [Spot 机器狗](https://bostondynamics.com/products/spot/)<br>[Atlas 通用人形](https://bostondynamics.com/atlas/) | 具身智能本体制造商，从液压驱动转向电机驱动 |
 | [灵心巧手](https://www.linkerbot.cn/index) | [Linker Hand L30（健绳驱动）](https://www.linkerbot.cn/product?page=L30)<br>[Linker Hand L20（连杆驱动）](https://www.linkerbot.cn/product?page=L20) | 主攻各类灵巧手 |
 | [灵巧智能 DexRobot](https://www.dex-robot.com/) | [Dexhand 021 灵巧手](https://www.dex-robot.com/productionDexhand) | 19 自由度量产灵巧手 |
@@ -151,10 +151,10 @@
 | [光轮智能](https://lightwheel.net/) |  | 具身智能数据平台 |
 | [智元机器人](https://www.zhiyuan-robot.com/about/167.html) | [远征 A2 人形机器人](https://www.zhiyuan-robot.com/products/A2)<br>[远征 A2-W 轮式人形](https://www.zhiyuan-robot.com/products/A2_W)<br>[灵犀 X1 人形机器人](https://www.zhiyuan-robot.com/products/X1)<br>[精灵 G1 轮式人形](https://www.zhiyuan-robot.com/products/A2_D) |  |
 | [Nvidia](https://www.nvidia.cn/industries/robotics/) |  | 具身智能基建公司 |
-| [求之科技](https://airbots.online/) | [TOK2 移动主从臂平台](https://airbots.online/zh/tok)<br>[MMK2 移动升降双臂平台](https://airbots.online/zh/mmk2)<br>Play 六轴机械臂 |  |
+| [求之科技](https://airbots.online/) | [TOK4 移动主从臂平台](https://airbots.online/products/tok4)<br>[MMK2 移动升降双臂平台](https://airbots.online/products/mmk2)<br>[AIRBOT Play 六轴机械臂](https://airbots.online/products/airbot-play) | [开发者文档](https://docs.airbots.online/) |
 | [穹彻智能](https://www.noematrix.ai/) |  |  |
 | [优必选](https://www.ubtrobot.com/cn/about/companyProfile) |  |  |
 | [具身风暴](https://www.robotstorm.tech) |  | 落地具身智能通用按摩机器人 |
-| [众擎机器人](https://engineai.com.cn/) | [SE 01](https://engineai.com.cn/product_one)<br>[PM 01](https://engineai.com.cn/product_fore) |  |
+| [众擎机器人](https://engineai.com.cn/) | [SE01](https://engineai.com.cn/product-se01.html)<br>[PM01](https://engineai.com.cn/product-pm01.html)<br>[T800](https://engineai.com.cn/product-t800.html) |  |
 | [魔法原子](https://www.magiclab.top/) | [MagicBot](https://www.magiclab.top/human)<br>[MagicDog](https://www.magiclab.top/dog) |  |
-| [帕西尼](https://www.paxini.com/) | [PX-6AX GEN2 触觉传感器](https://www.paxini.com/ax/gen2)<br>[DexH13 GEN2 灵巧手](https://www.paxini.com/dex/gen2)<br>[TORA-ONE 人形机器人](https://www.paxini.com/robot) |  |
+| [帕西尼](https://www.paxini.com/) | [PX-6AX GEN2 触觉传感器](https://www.paxini.com/ax)<br>[DexH13 GEN2 灵巧手](https://www.paxini.com/dex)<br>[TORA-ONE 人形机器人](https://www.paxini.com/robot) |  |

--- a/topics/hardware.md
+++ b/topics/hardware.md
@@ -45,7 +45,7 @@
 
 | 资源 | 链接 | 说明 |
 |---|---|---|
-| 《机器人学简介》（教材 PDF） | [link](./files/%E6%9C%BA%E5%99%A8%E4%BA%BA%E5%AD%A6%E7%AE%80%E4%BB%8B.pdf) | 质量高，适合系统性阅读 |
+| 《机器人学简介》（教材 PDF） | [link](../files/%E6%9C%BA%E5%99%A8%E4%BA%BA%E5%AD%A6%E7%AE%80%E4%BB%8B.pdf) | 质量高，适合系统性阅读 |
 | Robotic Systems（Illinois） | [link](https://motion.cs.illinois.edu/RoboticSystems/) | 偏“系统化机器人学”的组织方式 |
 
 ---
@@ -134,7 +134,7 @@
 
 | 公司 | 主营产品 | Others |
 |---|---|---|
-| [松灵 AgileX](https://www.agilex.ai/) | [PIPER 六轴机械臂](https://global.agilex.ai/products/piper)<br>[PIKA 数采方案](https://global.agilex.ai/products/pika)<br>[Cobot Magic 双臂遥操作平台](https://global.agilex.ai/products/cobot-magic)<br>[移动底盘系列](https://global.agilex.ai/collections/all) | 面向教育科研；[开源仓库](https://github.com/agilexrobotics) |
+| [松灵 AgileX](https://www.agilex.ai/) | [PIPER 六轴机械臂](https://global.agilex.ai/products/piper)<br>[PIKA 数采方案](https://global.agilex.ai/products/pika)<br>[Cobot Magic 双臂遥操作平台](https://global.agilex.ai/products/cobot-magic)<br>[全部产品（含移动底盘）](https://global.agilex.ai/collections/all) | 面向教育科研；[开源仓库](https://github.com/agilexrobotics) |
 | [宇树 Unitree](https://www.unitree.com/cn) | [四足机器人开发指南](https://www.yuque.com/ironfatty/nly1un/luo9gb)<br>[Go2 机器狗](https://www.unitree.com/cn/go2)<br>[AlienGo 机器狗](https://www.yuque.com/ironfatty/nly1un/dqcz3u)<br>[通用人形 H1](https://www.unitree.com/cn/h1)<br>[通用人形 G1](https://www.unitree.com/cn/g1) | 许多产出使用宇树的机器人作为硬件基础 |
 | [方舟无限 ARX](https://www.arx-x.com/?product/) | [X5 机械臂](https://www.arx-x.com/?product/21.html)<br>[X7 双臂平台](https://www.arx-x.com/?product/23.html)<br>[R5 机械臂](https://www.arx-x.com/?product/22.html) | 适合复现很多经典工作，例如 [aloha](https://mobile-aloha.github.io/cn.html)<br>[RoboTwin 松灵底盘 + 方舟臂](https://github.com/RoboTwin-Platform/RoboTwin) |
 | [波士顿动力 Boston Dynamics](https://bostondynamics.com/) | [Spot 机器狗](https://bostondynamics.com/products/spot/)<br>[Atlas 通用人形](https://bostondynamics.com/atlas/) | 具身智能本体制造商，从液压驱动转向电机驱动 |

--- a/topics/infrastructure.md
+++ b/topics/infrastructure.md
@@ -3,8 +3,8 @@
 > 这一章关注的不是“具体某个模型”，而是**支撑具身智能研究与系统落地的软件基础设施（Infrastructure）**。  
 > 仿真器决定你能构建怎样的世界，基准集决定你如何比较方法优劣，数据集决定模型最终学到什么样的行为分布。它们共同构成了具身智能中**最容易被忽视、但最影响上限与复现性的部分**。
 
-软件部分可以理解为三层：  
-**Simulators（仿真环境）** 决定你能“跑什么物理世界”；**Benchmarks（评测基准）** 决定你用什么任务衡量方法优劣；**Datasets（数据集）** 决定你能训练出怎样的策略分布。建议优先跑通“一个仿真器 + 一个基准 + 一个数据集”的最小闭环，再逐步扩展到多平台与多模态。
+软件部分可以理解为三层，外加一层工具链：  
+**Simulators（仿真环境）** 决定你能“跑什么物理世界”；**Benchmarks（评测基准）** 决定你用什么任务衡量方法优劣；**Datasets（数据集）** 决定你能训练出怎样的策略分布；最后的**工具链**则关系到你把策略接到环境上要付多少工程成本。建议优先跑通“一个仿真器 + 一个基准 + 一个数据集”的最小闭环，再逐步扩展到多平台与多模态。
 
 <section id="simulators"></section>
 
@@ -15,10 +15,10 @@
 | 仿真器 | 典型生态 / 对应基准与工具链 |
 |---|---|
 | IsaacGym | legged-gym：[link](https://github.com/leggedrobotics/legged_gym)<br>parkour（含蒸馏与真机部署）：[link](https://github.com/ZiwenZhuang/parkour)<br>extreme-parkour：[link](https://github.com/chengxuxin/extreme-parkour) |
-| IsaacSim | BEHAVIOR-1K：[link](https://behavior.stanford.edu/behavior-1k) + OmniGibson（工具链）：[link](https://behavior.stanford.edu/omnigibson/)<br>ARNOLD：[link](https://arnold-benchmark.github.io/)<br>GarmentLab：[link](https://garmentlab.github.io/) / DexGarmentLab：[link](https://wayrise.github.io/DexGarmentLab/) |
+| IsaacSim | BEHAVIOR-1K：[link](https://behavior.stanford.edu/) + OmniGibson（工具链）：[link](https://github.com/StanfordVL/OmniGibson)<br>ARNOLD：[link](https://arnold-benchmark.github.io/)<br>GarmentLab：[link](https://garmentlab.github.io/) / DexGarmentLab：[link](https://wayrise.github.io/DexGarmentLab/) |
 | MuJoCo | robosuite：[link](https://robosuite.ai/docs/overview.html) + robomimic（工具链）：[link](https://robomimic.github.io/)<br>LIBERO：[link](https://libero-project.github.io/main.html)<br>MetaWorld：[link](https://meta-world.github.io/)<br>Gymnasium-Robotics：[link](https://robotics.farama.org/)<br>RoboCasa：[link](https://github.com/robocasa/robocasa?tab=readme-ov-file)<br>RoboHive：[link](https://github.com/vikashplus/robohive) |
 | OmniSim | 平台：[link](https://github.com/omnilink-tech/omnisim)<br>Apache-2.0 机器人仿真器，提供 URDF 导入、HTTP/MCP Agent 控制、Newton CPU/GPU 物理、合成数据与可复现实验基准；Windows 提供 beta 安装包，Linux 为源码构建，macOS 物理尚未验证 |
-| SAPIEN | ManiSkill：[link](https://maniskill.readthedocs.io/en/latest/index.html)<br>RoboTwin：[link](https://github.com/TianxingChen/RoboTwin) |
+| SAPIEN | ManiSkill：[link](https://maniskill.readthedocs.io/en/latest/index.html)<br>RoboTwin 2.0：[link](https://github.com/RoboTwin-Platform/RoboTwin) / 文档：[link](https://robotwin-platform.github.io/doc/) |
 | CoppeliaSim | RLBench：[link](https://github.com/stepjam/RLBench)<br>PerAct2：[link](https://bimanual.github.io/)<br>COLOSSEUM：[link](https://robot-colosseum.github.io/) |
 | PyBullet | CALVIN：[link](https://github.com/mees/calvin?tab=readme-ov-file)<br>Ravens：[link](https://github.com/google-research/ravens)<br>VimaBench：[link](https://github.com/vimalabs/VimaBench) |
 | Genesis | 入口：[link](https://genesis-embodied-ai.github.io/) |
@@ -38,7 +38,9 @@
 
 | 基准 | 链接 | 一句话定位 |
 |---|---|---|
-| RoboTwin 2.0 | [link](https://github.com/robotwin-Platform/RoboTwin) | 程序化生成双臂任务数据与 50 个双臂评测任务（偏“双臂+规模化生成”） |
+| RoboTwin 2.0 | [link](https://github.com/RoboTwin-Platform/RoboTwin)<br>[link](https://robotwin-platform.github.io/doc/) | 程序化生成双臂任务数据与 50 个双臂评测任务（偏“双臂+规模化生成”） |
+| RoboDojo | [link](https://robodojo-benchmark.com/) | 同时提供仿真与真机任务，评测维度覆盖泛化、精度、长程与记忆（偏“统一评测”） |
+| RMBench | [link](https://rmbench.github.io/) | 专门考察记忆能力的操作基准，任务按记忆复杂度分级（偏“记忆依赖任务”） |
 | SimplerENV | [link](https://github.com/simpler-env/SimplerEnv) | 轻量化、可快速对比策略在操作任务上的表现 |
 | LIBERO | [link](https://github.com/Lifelong-Robot-Learning/LIBERO)<br>[link](https://libero-project.github.io/intro.html) | 程序化生成管道 + 视觉运动策略架构与终身学习设置（偏“终身/顺序学习”） |
 | CALVIN | [link](https://github.com/mees/calvin)<br>[link](http://calvin.cs.uni-freiburg.de/) | 语言条件 + 多模态输入 + 长视野操纵（偏“长程任务与规划”） |
@@ -70,4 +72,20 @@
 | BridgeData V2 | [link](https://rail-berkeley.github.io/bridgedata/) | 6 万轨迹；多环境多技能；目标图像/语言指令；包含远程操控与脚本执行 |
 | Ego4D Sounds | [link](https://ego4dsounds.github.io/) | 第一人称视频 + 环境声音；强调动作与声音对齐（声音模态很有价值） |
 | RH20T | [link](https://rh20t.github.io/) | 人机交互数据；含人脸与语音等敏感信息；体量大且提供缩减版（注意隐私与合规） |
-| 白虎数据集 | [link](https://www.openloong.org.cn/cn/dataset) | 异构机器人；多场景多任务；面向跨平台评估与训练（本体覆盖面广） |
+| 白虎数据集 | [link](https://www.openloong.org.cn/cn/) | 异构机器人；多场景多任务；面向跨平台评估与训练（本体覆盖面广） |
+| RoboTwin 2.0 Dataset | [link](https://robotwin-platform.github.io/doc/usage/collect-data.html) | 10 万条以上仿真轨迹；50 个双臂任务；clean / randomized 两档域随机化；可按任务单独下载 |
+
+---
+
+<section id="policy-serving"></section>
+
+## (4) 工具链 - 数据格式与策略部署
+
+前三节解决的是「在哪跑、比什么、用什么数据训」，还剩一件很占时间但不太被写进论文的事：**把一个策略真正接到环境上跑起来**。麻烦主要来自不统一——每个模型的依赖库、观测格式、动作空间都不一样，换一个仿真器常常要重写一遍胶水代码。下面两个项目分别从「统一数据格式」和「统一部署接口」两个角度减少这部分工作量。
+
+| 项目 | 链接 | 一句话定位 |
+|---|---|---|
+| LeRobot | [repo](https://github.com/huggingface/lerobot) | Hugging Face 的机器人学习栈，提供统一的数据集格式和多个策略的训练代码；它的数据格式目前基本是通用底座 |
+| XPolicyLab | [repo](https://github.com/XPolicyLab/XPolicyLab) | 把多个策略收敛到同一套部署接口，策略与环境可以各用自己的依赖环境、跨机器通信；适合在同一批任务上横向对比多个模型 |
+
+> 🌱 新手不必一开始就纠结这一层。只跑一个策略时，直接用该策略仓库自带的脚本最省事；等你需要**在同一套任务上比较多个模型**，或者撞上「策略要一个 torch 版本、仿真器要另一个」这类依赖冲突时，再回来看它们的价值会明显得多。


### PR DESCRIPTION
Repair 5 malformed links in the vision stack table where several URLs were collapsed into a single href, leaving them unclickable on GitHub. Update relocated resources (RoboTwin repo path, BEHAVIOR-1K, OmniGibson, OpenLoong dataset, 9 vendor product pages across 4 companies) and drop the retired SOTA Paper Rating entry. Also correct the PIPER arm name and bump TOK2 to TOK4.

Add the 2026 policy landscape to the algorithm chapter, covering the VLA / WAM / memory-augmented families and the current policy roster, a data format and policy deployment section to the infrastructure chapter, and a linked table of Chinese and English media sources to the README.

Restore the seven internal navigation anchors that had been stripped, which had broken all 14 references from the top nav and contents table.